### PR TITLE
Increase opening arrow volley on early immobile opponents

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -520,6 +520,10 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         // =================  PARADE ÉPÉE (long range)  ================
         val holdingSword = p.heldItem != null && p.heldItem.unlocalizedName.lowercase().contains("sword")
         val isStillNow = stillFrames >= stillFramesNeeded
+        if (now - gameStartAt < 2000 && isStillNow && openVolleyMax < 3) {
+            // Adversaire immobile durant les premières secondes : augmenter la salve d'ouverture
+            openVolleyMax = RandomUtils.randomIntInRange(3, 4)
+        }
         val oppHasBowNow = opp.heldItem != null && opp.heldItem.unlocalizedName.lowercase().contains("bow")
         val bowLikely = oppHasBowNow && (isStillNow || bowSlowFrames >= bowSlowFramesNeeded)
 


### PR DESCRIPTION
## Summary
- Detect opponents who remain still during the first 2s of a duel
- Expand the opening bow volley to 3-4 shots when early immobility is detected

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
