### PR TITLE
Use Bow feature in Blitz for long-range

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -2,6 +2,7 @@ package best.spaghetcodes.kira.bot.bots
 
 import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.MovePriority
+import best.spaghetcodes.kira.bot.features.Bow
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
@@ -10,7 +11,7 @@ import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 
-class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
+class Blitz : BotBase("/play duels_blitz_duel"), MovePriority, Bow {
 
     override fun getName(): String = "Blitz"
 
@@ -97,7 +98,13 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
             when {
                 distance > 8f -> {
                     // Essayer arc/proj à longue distance
-                    if (Inventory.setInvItem("bow")) {
+                    if (distance > 5f) {
+                        useBow(distance)
+                        lastKitSwitch = now
+                    } else {
+                        if (!Inventory.setInvItem("rod")) {
+                            Inventory.setInvItem("sword")
+                        }
                         lastKitSwitch = now
                     }
                 }


### PR DESCRIPTION
## Summary
- Switch Blitz kit logic to use Bow feature for ranged engagement
- Ensure bow usage only when target is beyond 5 blocks, otherwise retain sword or rod

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy; HTTP/1.1 403 Forbidden)*

------