### PR TITLE
Delay quick pearl until gap consumed when cycle active

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -567,7 +567,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                 }, RandomUtils.randomIntInRange(250, 500))
             }
             val timeUntilGap = nextGapAt - now
-            if (timeUntilGap <= 10_000) {
+            if (gapCycleStarted && timeUntilGap <= 12_000L) {
                 val pre = RandomUtils.randomIntInRange(110, 160)
                 val hold = 2100
                 eatGap(pre, hold, distance, player, target)


### PR DESCRIPTION
## Summary
- Check for an active gap cycle and upcoming gap before launching quick pearls
- Consume the gapple and wait for completion before throwing the pearl when the cycle is active

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb07a63f08329b274002214aa9669