### PR TITLE
Fix Combo class scope for lifecycle methods

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -267,7 +267,6 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
                     }, delayToPearl)
                 }
             }
-        }
         chainPotion()
     }
 


### PR DESCRIPTION
## Summary
- remove stray brace so lifecycle methods reside inside `Combo` class

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb38a93f88329aed607bf122cb3fa