### PR TITLE
feat: add hit-and-block config

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -52,6 +52,12 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SWITCH, name = "Enable Kira Hits", description = "Whether the bot should perform hits.", category = "Combat")
     var enableHits = true
 
+    @Property(type = PropertyType.SWITCH, name = "Hit and Block", description = "Block after hitting an opponent.", category = "Combat")
+    var hitAndBlock = false
+
+    @Property(type = PropertyType.SLIDER, name = "Hit and Block Percent", description = "Chance of blocking after hitting.", category = "Combat", min = 0, max = 100, increment = 5)
+    var hitAndBlockPercent = 50
+
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)
     var minCPS = 15
 
@@ -168,6 +174,8 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         addDependency("dodgeWLR", "enableDodging")
         addDependency("dodgeLostTo", "enableDodging")
         addDependency("dodgeNoStats", "enableDodging")
+        addDependency("hitAndBlock", "enableHits")
+        addDependency("hitAndBlockPercent", "hitAndBlock")
 
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->


### PR DESCRIPTION
## Summary
- add `hitAndBlock` switch and related percentage slider to combat config
- block hit-and-block settings when hits are disabled

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bf43b5a83c8329b1b7eab93c53758d