### PR TITLE
feat: add hit-and-block behavior

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -62,6 +62,12 @@ object Mouse {
             KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindAttack.keyCode, true)
             if (kira.mc.objectMouseOver != null && kira.mc.objectMouseOver.entityHit != null) {
                 kira.mc.playerController.attackEntity(kira.mc.thePlayer, kira.mc.objectMouseOver.entityHit)
+                if (kira.config?.hitAndBlock == true && kira.config?.enableHits == true) {
+                    val hitAndBlockPercent = kira.config?.hitAndBlockPercent ?: 0
+                    if (RandomUtils.randomIntInRange(0, 99) < hitAndBlockPercent) {
+                        rClick(RandomUtils.randomIntInRange(60, 120))
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add optional post-attack block chance

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68bf451ee5a48329bb6e88a713fc9185