### PR TITLE
Add configurable hit counter for auto-blocking

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -22,11 +22,19 @@ object Mouse {
 
     private var leftClickDur = 0
 
+    private var hitsUntilBlock = 0
+
     private var lastLeftClick = 0L
 
     private var runningRotations: FloatArray? = null
 
     private var splashAim = 0.0
+
+    private fun resetHitsUntilBlock() {
+        val minHits = kira.config?.hitAndBlockMinHits ?: 1
+        val maxHits = kira.config?.hitAndBlockMaxHits ?: 1
+        hitsUntilBlock = RandomUtils.randomIntInRange(minHits, maxHits)
+    }
 
     // ---- Bow ballistic compensation (pitch) ----
     private fun bowDistanceToOpponent(): Float {
@@ -63,9 +71,13 @@ object Mouse {
             if (kira.mc.objectMouseOver != null && kira.mc.objectMouseOver.entityHit != null) {
                 kira.mc.playerController.attackEntity(kira.mc.thePlayer, kira.mc.objectMouseOver.entityHit)
                 if (kira.config?.hitAndBlock == true && kira.config?.enableHits == true) {
-                    val hitAndBlockPercent = kira.config?.hitAndBlockPercent ?: 0
-                    if (RandomUtils.randomIntInRange(0, 99) < hitAndBlockPercent) {
+                    if (hitsUntilBlock <= 0) {
+                        resetHitsUntilBlock()
+                    }
+                    hitsUntilBlock--
+                    if (hitsUntilBlock <= 0) {
                         rClick(RandomUtils.randomIntInRange(60, 120))
+                        resetHitsUntilBlock()
                     }
                 }
             }

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -58,6 +58,12 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
     @Property(type = PropertyType.SLIDER, name = "Hit and Block Percent", description = "Chance of blocking after hitting.", category = "Combat", min = 0, max = 100, increment = 5)
     var hitAndBlockPercent = 50
 
+    @Property(type = PropertyType.NUMBER, name = "Hit and Block Min Hits", description = "Minimum hits before blocking.", category = "Combat", min = 1, max = 20, increment = 1)
+    var hitAndBlockMinHits = 2
+
+    @Property(type = PropertyType.NUMBER, name = "Hit and Block Max Hits", description = "Maximum hits before blocking.", category = "Combat", min = 1, max = 20, increment = 1)
+    var hitAndBlockMaxHits = 5
+
     @Property(type = PropertyType.SLIDER, name = "Min CPS", description = "The minimum CPS that the bot will be clicking at.", category = "Combat", min = 0, max = 25)
     var minCPS = 15
 
@@ -176,6 +182,8 @@ class Config : Vigilant(File(kira.configLocation).apply { parentFile.mkdirs() },
         addDependency("dodgeNoStats", "enableDodging")
         addDependency("hitAndBlock", "enableHits")
         addDependency("hitAndBlockPercent", "hitAndBlock")
+        addDependency("hitAndBlockMinHits", "hitAndBlock")
+        addDependency("hitAndBlockMaxHits", "hitAndBlock")
 
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -294,6 +294,8 @@ class CustomConfigGUI : GuiScreen() {
         toggle("Enable Kira Hits", x, y, { cfg.enableHits }, { cfg.enableHits = it }); y += 20
         toggle("Hit & Block", x, y, { cfg.hitAndBlock }, { cfg.hitAndBlock = it }); y += 20
         number("Hit & Block %", x, y, { cfg.hitAndBlockPercent }, { cfg.hitAndBlockPercent = it }, 0, 100, 5); y += 20
+        number("Min Hits Until Block", x, y, { cfg.hitAndBlockMinHits }, { cfg.hitAndBlockMinHits = it }, 1, 20, 1); y += 20
+        number("Max Hits Until Block", x, y, { cfg.hitAndBlockMaxHits }, { cfg.hitAndBlockMaxHits = it }, 1, 20, 1); y += 24
         number("Min CPS", x, y, { cfg.minCPS }, { cfg.minCPS = it }, 0, 25, 1); y += 20
         number("Max CPS", x, y, { cfg.maxCPS }, { cfg.maxCPS = it }, 0, 25, 1); y += 24
 


### PR DESCRIPTION
## Summary
- Track hits until blocking and reset counter after each block
- Add min/max hit settings for blocking strategy in config and GUI

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bf45dcad688329a5f01e6bf629d8ab