### PR TITLE
Add random-based blocking to left clicks

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -76,7 +76,9 @@ object Mouse {
                     }
                     hitsUntilBlock--
                     if (hitsUntilBlock <= 0) {
-                        rClick(RandomUtils.randomIntInRange(60, 120))
+                        if (RandomUtils.randomIntInRange(0, 100) < (kira.config?.hitAndBlockPercent ?: 100)) {
+                            rClick(RandomUtils.randomIntInRange(60, 120))
+                        }
                         resetHitsUntilBlock()
                     }
                 }


### PR DESCRIPTION
## Summary
- Only block after hit based on configurable probability

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68bfb887118083299955a3da2f8c56ce