### PR TITLE
Limit tactical jumps to distant opponents

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -605,18 +605,11 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         // ========== JUMPS CONTEXTUELS (hors parade/proj) ==========
         if (!Mouse.rClickDown && !projectileActive && (now - lastGotHitAt) > 260 && !startupJumping) {
-            val facingAway = EntityUtils.entityFacingAway(p, opp)
-            val oppVeryStill = (stillFrames >= 6)
-            if (distance > 8.0f) {
-                if (p.onGround && now - lastTacticalJumpAt >= 520) {
-                    Movement.singleJump(RandomUtils.randomIntInRange(150, 230))
-                    lastTacticalJumpAt = now
-                }
-            } else if (distance in 4.5f..8.0f && (facingAway || oppVeryStill)) {
-                if (p.onGround && now - lastTacticalJumpAt >= 720) {
-                    Movement.singleJump(RandomUtils.randomIntInRange(150, 230))
-                    lastTacticalJumpAt = now
-                }
+            if (distance >= 6.0f && p.onGround && now - lastTacticalJumpAt >= 520) {
+                Movement.singleJump(RandomUtils.randomIntInRange(150, 230))
+                lastTacticalJumpAt = now
+            } else {
+                Movement.stopJumping()
             }
         }
 


### PR DESCRIPTION
## Summary
- Restrict contextual jumps to cases when enemies are at least ~6 blocks away
- Stop jumping when opponents are closer to avoid unnecessary hops

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb4c64488329baceca6783db8bf3