### PR TITLE
Start Classic bot with bow

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -187,7 +187,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         Movement.startForward()
         Mouse.rClickUp()
 
-        TimeUtils.setTimeout({ Inventory.setInvItem("rod") }, 200)
+        Inventory.setInvItem("bow")
         firstRod = true
 
         startupJumping = true


### PR DESCRIPTION
## Summary
- Start the ClassicV2 bot with the bow instead of the rod so the first rod is handled by `castRodNow`.

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcb755efc83298fd84739f4338e6d