### PR TITLE
Ensure rod casts ignore left clicks

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -328,9 +328,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
     private fun castRodNow(distanceNow: Float) {
         fun doClick() {
             val nowClick = System.currentTimeMillis()
-
-            Mouse.setUsingProjectile(true)
-            Mouse.rClick(RandomUtils.randomIntInRange(70, 95))
+            useRodImmediate()
             reentryRodGraceUntil = 0L
 
             // HOLD DE ROD APRÈS CAST — presets:
@@ -351,12 +349,6 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
             lastRodAttemptAt = nowClick
             pendingRodCheck = true
             lastOppHurtTime = opponent()?.hurtTime ?: 0
-
-            // Retour à l'épée automatique après le hold
-            TimeUtils.setTimeout({
-                Inventory.setInvItem("sword")
-                Mouse.setUsingProjectile(false)
-            }, max(holdMs + 20, settle))
 
             lastRodUse = nowClick
 
@@ -385,6 +377,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
             }
         }
 
+        Mouse.stopLeftAC()
         // Sélection + CLIC TOUT DE SUITE
         val held = mc.thePlayer?.heldItem?.unlocalizedName?.lowercase()
         if (held == null || !held.contains("rod")) {


### PR DESCRIPTION
## Summary
- Stop left autoclicker before rod cast and verify held rod
- Use shared `useRodImmediate` helper for consistent rod behavior

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeff09e10832996f40dde8ba74fe1