### PR TITLE
Fix Kotlin test dependency resolution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,12 +46,14 @@ dependencies {
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
 
     testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit"))
     testImplementation("io.mockk:mockk:1.13.5")
 }
 
 repositories {
     maven("https://repo.essential.gg/repository/maven-public")
     maven("https://repo.spongepowered.org/repository/maven-public")
+    mavenCentral()
 }
 
 tasks {


### PR DESCRIPTION
## Summary
- add `kotlin("test-junit")` dependency for test sources
- include `mavenCentral()` to resolve standard test libraries

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.7.10'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c027a1f51483299d45dc43103018b0