### PR TITLE
Use explicit kotlin-test-junit artifact for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,8 +45,7 @@ dependencies {
     compileOnly("org.spongepowered:mixin:0.8.5-SNAPSHOT")
     annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
 
-    testImplementation(kotlin("test"))
-    testImplementation(kotlin("test-junit"))
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.7.10")
     testImplementation("io.mockk:mockk:1.13.5")
 }
 


### PR DESCRIPTION
## Summary
- replace Kotlin test dependencies with explicit `kotlin-test-junit:1.7.10`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c029de3bb4832983d1358d8ec8892f