### PR TITLE
Enable sword attacks in multiple bots

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -6,6 +6,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -67,7 +68,7 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
+        if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val now = System.currentTimeMillis()

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Boxing.kt
@@ -80,7 +80,7 @@ class Boxing : BotBase("/play duels_boxing_duel"), MovePriority {
             // tracking ON en continu
             Mouse.startTracking()
 
-            Mouse.stopLeftAC()
+            if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
             if (combo >= 3 && distance >= 3.2f && mc.thePlayer.onGround) {
                 Movement.singleJump(RandomUtils.randomIntInRange(100, 150))

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import best.spaghetcodes.kira.utils.ChatUtils
 import net.minecraft.init.Blocks
@@ -280,7 +281,6 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
 
         val now = System.currentTimeMillis()
         val distance = EntityUtils.getDistanceNoY(p, opp)
@@ -320,6 +320,9 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         // ------------------
 
         val holdingSword = p.heldItem != null && p.heldItem.unlocalizedName.lowercase().contains("sword")
+
+        val shouldAttack = kira.config?.enableHits == true && holdingSword && !projectileActive && !Mouse.rClickDown && distance < 10f
+        if (shouldAttack) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         // Annuler l’ARC au contact
         if (projectileActive && Mouse.rClickDown) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -8,6 +8,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -424,7 +425,6 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         if (!p.isSprinting) Movement.startSprinting()
         Mouse.startTracking()
-        Mouse.stopLeftAC()
 
         // Sauts de début : ACTIFS EN CONTINU jusqu'au PREMIER brandissage d'ARC
         if (startupJumping) {
@@ -483,6 +483,10 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         val projectileActive =
             Mouse.isUsingProjectile() || now < projectileGraceUntil || now < pendingProjectileUntil || now < actionLockUntil
+
+        val holdingSword = p.heldItem != null && p.heldItem.unlocalizedName.lowercase().contains("sword")
+        val shouldAttack = kira.config?.enableHits == true && holdingSword && !projectileActive && !Mouse.rClickDown && distance < 10f
+        if (shouldAttack) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
         // Avance / arrêt (avec stick avant)
         if (now < forwardStickUntil) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -250,18 +250,14 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         gameStartAt = System.currentTimeMillis()
 
         openingPhase = true
-        openingScheduled = true
+        openingScheduled = false
 
-        TimeUtils.setTimeout({
-            val player = mc.thePlayer
-            val target = opponent()
-            if (player == null || target == null) {
-                openingScheduled = false
-                return@setTimeout
-            }
-            startOpening(player, target)
+        val player = mc.thePlayer
+        val target = opponent()
+        if (player != null && target != null) {
             openingScheduled = true
-        }, 0)
+            startOpening(player, target)
+        }
 
         strengthDosesUsed = 0
         lastPotion = 0L

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -7,6 +7,7 @@ import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
 import best.spaghetcodes.kira.bot.player.Movement
+import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
@@ -108,8 +109,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             // tracking ON en continu
             Mouse.startTracking()
 
-            // auto-CPS OFF
-            Mouse.stopLeftAC()
+            // auto-CPS ON
+            if (kira.config?.enableHits == true) Mouse.startLeftAC() else Mouse.stopLeftAC()
 
             if (distance > 8.8f) {
                 if (opponent() != null && opponent()!!.heldItem != null && opponent()!!.heldItem.unlocalizedName.lowercase().contains("bow")) {


### PR DESCRIPTION
## Summary
- trigger Combo's potion and golden apple sequence as soon as a duel begins
- attack in Classic and ClassicV2 only when close, holding a sword, and hits are enabled

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c03b0c65908329bf67befa8f353b0f