### PR TITLE
Adjust bow pitch compensation thresholds

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -44,17 +44,14 @@ object Mouse {
      */
     private fun bowPitchComp(distance: Float): Float {
         return when {
-            // courte portée : quasi aucune compensation
-            distance < 10f  -> 0.0f
-            distance < 12f  -> 0.3f
-            distance < 14f  -> 0.8f
-            distance < 16f  -> 1.0f
-            // milieu de portée : valeurs revues à la baisse
-            distance < 20f  -> 1.6f
-            distance < 24f  -> 2.3f
-            distance < 28f  -> 3.8f
-            // très longue distance : légère réduction également
-            else            -> 5.2f
+            // offset nul jusqu'à ~30 blocs
+            distance < 30f -> 0.0f
+            // augmentation progressive avec la distance
+            distance < 35f -> 1.0f
+            distance < 40f -> 2.0f
+            distance < 50f -> 3.0f
+            distance < 60f -> 4.0f
+            else -> 5.0f
         }
     }
     // --------------------------------------------


### PR DESCRIPTION
## Summary
- keep bow offset at 0 until ~30 blocks
- ramp offset gradually up to 5° for long shots

## Testing
- `./gradlew test` *(HTTP 403 downloading Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b30da06883299c08f4567cad0372