### PR TITLE
Always compute rotations toward target

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/EntityUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/EntityUtils.kt
@@ -53,6 +53,8 @@ object EntityUtils {
         return if (target == null || player == null) {
             null
         } else {
+            // Always calculate yaw and pitch toward the target regardless of
+            // crosshair distance.
             val pos: Vec3?
             if (center) {
                 pos = Vec3(target.posX, target.posY + target.eyeHeight, target.posZ)
@@ -152,12 +154,6 @@ object EntityUtils {
                 player.rotationPitch + diffPitch / smoothing
             )
         }
-    }
-
-    fun crossHairDistance(yaw: Float, pitch: Float, player: EntityPlayer): Float {
-        val nYaw = abs(player.rotationYaw - yaw)
-        val nPitch = abs(player.rotationPitch - pitch)
-        return MathHelper.sqrt_float(nYaw * nYaw + nPitch * nPitch)
     }
 
     fun getDistanceNoY(player: EntityPlayer?, target: Entity?): Float {


### PR DESCRIPTION
## Summary
- Ensure getRotations always calculates yaw/pitch toward the target without crosshair-distance gating
- Remove unused crossHairDistance helper

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy - HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c176cf958c8329a3b26cd5a749ab9f