### PR TITLE
Remove outdated enableKiraHit flag

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -134,7 +134,7 @@ object Mouse {
     }
 
     private fun leftACFunc() {
-        if (kira.bot?.toggled() == true && kira.config?.enableHits == true && kira.config?.enableKiraHit == true && leftAC) {
+        if (kira.bot?.toggled() == true && kira.config?.enableHits == true && leftAC) {
             if (!kira.mc.thePlayer.isUsingItem) {
                 val minCPS = kira.config?.minCPS ?: 10
                 val maxCPS = kira.config?.maxCPS ?: 14
@@ -170,7 +170,7 @@ object Mouse {
     fun onTick(event: TickEvent.ClientTickEvent) {
         if (kira.mc.thePlayer != null && kira.bot?.toggled() == true) {
             if (leftAC) leftACFunc()
-            if (kira.config?.enableKiraHit == true) {
+            if (kira.config?.enableHits == true) {
                 if (leftClickDur > 0) {
                     val key = kira.mc.gameSettings.keyBindAttack.keyCode
                     KeyBinding.onTick(key)


### PR DESCRIPTION
## Summary
- use existing `enableHits` toggle instead of removed `enableKiraHit`

## Testing
- `./gradlew build` *(failed: HTTP/1.1 403 Forbidden while downloading gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68c17c90b8188329900e0bc1c5f8c1d8