### PR TITLE
Improve close-range strafe timing

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -177,6 +177,15 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
     private var closeStrafeToggleAt = 0L
     // --------------------------------------------------
 
+    private fun computeCloseStrafeNext(distance: Float): Long {
+        val range = when {
+            distance < 1.4f -> 340..480
+            distance < 2.0f -> 280..420
+            else -> 220..340
+        }
+        return RandomUtils.randomIntInRange(range.first, range.last).toLong()
+    }
+
     // ====================  LIFECYCLE  ==================
     override fun onGameStart() {
         Mouse.startTracking()
@@ -831,35 +840,42 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
             // ======= Close-range strafe logic (< 2.6 blocs) =======
             if (distance < 2.6f) {
-                // Sélection/renouvèlement du mode
                 if (now >= closeStrafeNextAt) {
-                    val roll = RandomUtils.randomIntInRange(0, 99)
-                    closeStrafeMode = when {
-                        roll < 50 -> MODE_BURST              // 50% très rapide
-                        roll < 75 -> MODE_HOLD_LEFT          // 25% maintien gauche
-                        else     -> MODE_HOLD_RIGHT          // 25% maintien droit
-                    }
-                    closeStrafeNextAt = now + when (closeStrafeMode) {
-                        MODE_BURST -> RandomUtils.randomIntInRange(280, 420).toLong()
-                        else       -> RandomUtils.randomIntInRange(220, 340).toLong()
-                    }
-                    if (closeStrafeMode == MODE_BURST) {
-                        closeStrafeToggleAt = now + RandomUtils.randomIntInRange(60, 110)
+                    closeStrafeMode = if (distance < 1.8f) {
+                        if (RandomUtils.randomBool()) MODE_HOLD_LEFT else MODE_HOLD_RIGHT
                     } else {
-                        strafeDir = if (closeStrafeMode == MODE_HOLD_LEFT) -1 else 1
+                        val roll = RandomUtils.randomIntInRange(0, 99)
+                        when {
+                            roll < 50 -> MODE_BURST
+                            roll < 75 -> MODE_HOLD_LEFT
+                            else -> MODE_HOLD_RIGHT
+                        }
                     }
-                } else if (closeStrafeMode == MODE_BURST && now >= closeStrafeToggleAt) {
+                    closeStrafeNextAt = now + computeCloseStrafeNext(distance)
+                    if (closeStrafeMode == MODE_BURST) {
+                        closeStrafeToggleAt = now + RandomUtils.randomIntInRange(150, 220)
+                    } else {
+                        val newDir = if (closeStrafeMode == MODE_HOLD_LEFT) -1 else 1
+                        if (newDir != strafeDir && now - lastStrafeSwitch >= 150) {
+                            strafeDir = newDir
+                            lastStrafeSwitch = now
+                        } else {
+                            strafeDir = newDir
+                        }
+                    }
+                } else if (closeStrafeMode == MODE_BURST && now >= closeStrafeToggleAt && now - lastStrafeSwitch >= 150) {
                     strafeDir = -strafeDir
-                    closeStrafeToggleAt = now + RandomUtils.randomIntInRange(60, 110)
+                    lastStrafeSwitch = now
+                    closeStrafeToggleAt = now + RandomUtils.randomIntInRange(150, 220)
                 }
 
-                // Poids et mouvement
                 val weightClose = 4
                 if (strafeDir < 0) movePriority[0] += weightClose else movePriority[1] += weightClose
                 Movement.startForward()
                 Movement.startSprinting()
                 randomStrafe = false
             } else {
+                closeStrafeNextAt = 0L
                 // ======= Medium/long range =======
                 if (distance < 6.5f && now - lastStrafeSwitch > RandomUtils.randomIntInRange(820, 1100)) {
                     strafeDir = -strafeDir

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -36,7 +36,8 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
     private var consumingUntil = 0L
     private var lastFarJumpAt = 0L
     private var strafeDir = 1
-    private var closeStrafeToggleAt = 0L
+    private var closeStrafeNextAt = 0L
+    private var lastCloseStrafeSwitch = 0L
     private var lockLeftAC = false
     private var lockLeftACSince = 0L
     private var tapping = false
@@ -45,6 +46,14 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
     private val strengthPeriodMs = 294_000L
     private val gapPeriodMs = 26_000L
     private fun isConsuming(): Boolean = System.currentTimeMillis() < consumingUntil
+
+    private fun computeCloseStrafeDelay(distance: Float): Long {
+        return when {
+            distance < 1.4f -> 340L
+            distance < 2.0f -> 260L
+            else -> 200L
+        }
+    }
 
     enum class ArmorEnum { BOOTS, LEGGINGS, CHESTPLATE, HELMET }
     private var armor = hashMapOf(0 to 1, 1 to 1, 2 to 1, 3 to 1)
@@ -540,20 +549,18 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
             } else {
                 if (distance < 2.6f) {
                     val nowMs = System.currentTimeMillis()
-                    if (nowMs >= closeStrafeToggleAt) {
+                    if (nowMs >= closeStrafeNextAt && nowMs - lastCloseStrafeSwitch >= 150) {
                         strafeDir = -strafeDir
-                        closeStrafeToggleAt = nowMs + RandomUtils.randomIntInRange(40, 90)
-                        val tapDuration = RandomUtils.randomIntInRange(40, 80)
-                        if (strafeDir < 0) {
-                            Combat.aTap(tapDuration)
-                        } else {
-                            Combat.dTap(tapDuration)
-                        }
+                        lastCloseStrafeSwitch = nowMs
+                        closeStrafeNextAt = nowMs + computeCloseStrafeDelay(distance)
+                    } else if (closeStrafeNextAt == 0L) {
+                        closeStrafeNextAt = nowMs + computeCloseStrafeDelay(distance)
                     }
                     val weightClose = 6
                     if (strafeDir < 0) movePriority[0] += weightClose else movePriority[1] += weightClose
                     randomStrafe = false
                 } else {
+                    closeStrafeNextAt = 0L
                     if (distance < 4f && combo > 2) {
                         val rotations = EntityUtils.getRotations(target, player, false)
                         if (rotations != null) {


### PR DESCRIPTION
## Summary
- replace tap strafes with hold timers in Combo bot
- add distance-aware close-range strafe state machine with minimum 150ms reversals

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b7dce9188329b3828f9e96e52f3d