### PR TITLE
Fix leftover close strafe toggle reference

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -288,7 +288,7 @@ class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
         lastFarJumpAt = 0L
 
         strafeDir = if (RandomUtils.randomIntInRange(0, 1) == 1) 1 else -1
-        closeStrafeToggleAt = 0L
+        closeStrafeNextAt = 0L
 
         lockLeftAC = false
         lockLeftACSince = 0L


### PR DESCRIPTION
## Summary
- reset close strafe scheduling with `closeStrafeNextAt` instead of removed `closeStrafeToggleAt`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c1ba8b1be88329ad175fda13895b62