### PR TITLE
Shift rotation threshold to mouse tick handling

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -202,7 +202,14 @@ object Mouse {
             var rotations = EntityUtils.getRotations(kira.mc.thePlayer, kira.bot?.opponent(), false)
 
             if (rotations != null) {
-                val distance = EntityUtils.getDistanceNoY(kira.mc.thePlayer, kira.bot?.opponent()!!)
+                val player = kira.mc.thePlayer!!
+                val smoothing = 3f
+                val targetYaw = player.rotationYaw + (rotations[0] - player.rotationYaw) * smoothing
+                val targetPitch = player.rotationPitch + (rotations[1] - player.rotationPitch) * smoothing
+                if (EntityUtils.crossHairDistance(targetYaw, targetPitch, player) <= 6f) {
+                    return
+                }
+                val distance = EntityUtils.getDistanceNoY(player, kira.bot?.opponent()!!)
                 val closeCombat = distance <= 3.5f
 
                 if (_runningAway) {

--- a/src/main/kotlin/best/spaghetcodes/kira/utils/EntityUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/EntityUtils.kt
@@ -142,20 +142,16 @@ object EntityUtils {
             val diffPitch = MathHelper.wrapAngleTo180_float(pitch - player.rotationPitch)
             val smoothing = 3f
 
-            if (crossHairDistance(yaw, pitch, player) > 5f) {
-                if (raw) {
-                    floatArrayOf(
-                        diffYaw / smoothing,
-                        diffPitch / smoothing
-                    )
-                } else floatArrayOf(
+            if (raw) {
+                floatArrayOf(
+                    diffYaw / smoothing,
+                    diffPitch / smoothing
+                )
+            } else {
+                floatArrayOf(
                     player.rotationYaw + diffYaw / smoothing,
                     player.rotationPitch + diffPitch / smoothing
                 )
-            } else {
-                if (raw) {
-                    floatArrayOf(0f, 0f)
-                } else floatArrayOf(player.rotationYaw, player.rotationPitch)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Always compute yaw/pitch toward targets in `EntityUtils.getRotations`
- Apply small-angle rotation threshold in `Mouse.onTick` to avoid head snapping

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1da6db0f483298a0ce576fa5c9ce7