### PR TITLE
fix: resolve Kotlin warnings

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -59,7 +59,6 @@ class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
     }
 
     override fun onAttack() {
-        val distance = EntityUtils.getDistanceNoY(mc.thePlayer, opponent())
         ChatUtils.info("W-Tap 100")
         Combat.wTap(100)
         tapping = true

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/BowDuel.kt
@@ -211,23 +211,26 @@ class BowDuel : BotBase("/play duels_bow_duel"), Bow, MovePriority {
         // --------- Strafe / déplacement ----------
         val movePriority = arrayListOf(0, 0)
         var clear = false
-        var randomStrafe = false
 
-        // Strafe forcé pendant hop-shot
-        if (now < forceStrafeUntil) {
-            val w = 10
-            if (forceStrafeDir < 0) movePriority[0] += w else movePriority[1] += w
-            randomStrafe = false
-        } else if (now < evasionUntil) {
-            val w = if (distance > 18f) 9 else 7
-            if (strafeDir < 0) movePriority[0] += w else movePriority[1] += w
-            randomStrafe = false
-        } else {
-            // strafe “intelligent” face à la cible
-            randomStrafe = true
-            val rotations = EntityUtils.getRotations(opp, p, false)
-            if (rotations != null && abs(rotations[0]) > 0.0f) {
-                if (rotations[0] < 0) movePriority[1] += 3 else movePriority[0] += 3
+        val randomStrafe = when {
+            // Strafe forcé pendant hop-shot
+            now < forceStrafeUntil -> {
+                val w = 10
+                if (forceStrafeDir < 0) movePriority[0] += w else movePriority[1] += w
+                false
+            }
+            now < evasionUntil -> {
+                val w = if (distance > 18f) 9 else 7
+                if (strafeDir < 0) movePriority[0] += w else movePriority[1] += w
+                false
+            }
+            else -> {
+                // strafe “intelligent” face à la cible
+                val rotations = EntityUtils.getRotations(opp, p, false)
+                if (rotations != null && abs(rotations[0]) > 0.0f) {
+                    if (rotations[0] < 0) movePriority[1] += 3 else movePriority[0] += 3
+                }
+                true
             }
         }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -207,8 +207,7 @@ class CustomConfigGUI : GuiScreen() {
         y: Int,
         buf: String,
         isFocused: Boolean,
-        onFocus: () -> Unit,
-        setBuf: (String) -> Unit
+        onFocus: () -> Unit
     ): Int {
         val fieldY = y - scroll
         drawString(fontRendererObj, label, x, fieldY, -1)
@@ -267,8 +266,7 @@ class CustomConfigGUI : GuiScreen() {
             y = y,
             buf = startMsgBuf,
             isFocused = (focus == Tf.START_MSG),
-            onFocus = { focus = Tf.START_MSG },
-            setBuf = { s: String -> startMsgBuf = s }
+            onFocus = { focus = Tf.START_MSG }
         )
         number("Start Message Delay (ms)", x, y, { cfg.startMessageDelay }, { cfg.startMessageDelay = it }, 50, 1000, 50); y += 24
 
@@ -279,8 +277,7 @@ class CustomConfigGUI : GuiScreen() {
             y = y,
             buf = ggMsgBuf,
             isFocused = (focus == Tf.GG_MSG),
-            onFocus = { focus = Tf.GG_MSG },
-            setBuf = { s: String -> ggMsgBuf = s }
+            onFocus = { focus = Tf.GG_MSG }
         )
         number("AutoGG Delay (ms)", x, y, { cfg.ggDelay }, { cfg.ggDelay = it }, 50, 1000, 50); y += 20
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/StatsOverlay.kt
@@ -12,7 +12,7 @@ class StatsOverlay {
     private val df = DecimalFormat("#.##")
 
     @SubscribeEvent
-    fun onRender(event: RenderGameOverlayEvent.Text) {
+    fun onRender(@Suppress("UNUSED_PARAMETER") event: RenderGameOverlayEvent.Text) {
         if (kira.config?.showStatsOverlay == false) return
 
         val mc = kira.mc


### PR DESCRIPTION
## Summary
- remove unused distance variable in Blitz bot
- streamline random strafe logic in BowDuel
- drop unused buffer setter from CustomConfigGUI text fields
- silence unused event parameter in StatsOverlay

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c24ebb98a88329b4e7ea8f5cfeb631