### PR TITLE
Add configurable hit and block feature

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -3,6 +3,9 @@ package best.spaghetcodes.kira.bot
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.bot.player.*
 import best.spaghetcodes.kira.core.KeyBindings
+import best.spaghetcodes.kira.core.Config
+import best.spaghetcodes.kira.bot.bots.*
+import best.spaghetcodes.kira.bot.features.HitBlock
 import best.spaghetcodes.kira.utils.*
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
@@ -21,6 +24,7 @@ import net.minecraft.network.play.server.S19PacketEntityStatus
 import net.minecraft.network.play.server.S3EPacketTeams
 import net.minecraft.network.play.server.S45PacketTitle
 import net.minecraft.util.EnumChatFormatting
+import net.minecraft.item.ItemSword
 import net.minecraftforge.client.event.ClientChatReceivedEvent
 import net.minecraftforge.event.entity.EntityJoinWorldEvent
 import net.minecraftforge.event.entity.player.AttackEntityEvent
@@ -58,6 +62,12 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     protected var combo = 0
     protected var opponentCombo = 0
     protected var ticksSinceHit = 0
+
+    // Hit & Block state
+    private var hbNextAllowedAt = 0L
+    private var hbHitsSince = 0
+    private var hbTargetHits = 0
+    private var hbLastHitAt = 0L
 
     private var reconnectTimer: Timer? = null
 
@@ -117,6 +127,54 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
 
     // ----------------------------------------------------
 
+    private fun performHitBlock(now: Long, cfg: Config) {
+        val dur = RandomUtils.randomIntInRange(40, 80)
+        val delay = RandomUtils.randomIntInRange(0, 20)
+        TimeUtils.setTimeout({ Mouse.rClick(dur) }, delay)
+        val interval = (cfg.hitBlockMinInterval + RandomUtils.randomIntInRange(-20, 20)).coerceAtLeast(0)
+        hbNextAllowedAt = now + interval
+    }
+
+    private fun maybeHitBlock() {
+        val cfg = kira.config ?: return
+        if (!cfg.hitBlock) return
+        if (this !is HitBlock) return
+        val player = mc.thePlayer ?: return
+        val opp = opponent ?: return
+        if (EntityUtils.getDistanceNoY(player, opp) > 4f) return
+        val item = player.heldItem?.item
+        if (item !is ItemSword) return
+
+        val now = System.currentTimeMillis()
+        val allowed = now >= hbNextAllowedAt
+
+        when (cfg.hitBlockMode) {
+            0 -> { // Chance
+                if (allowed && cfg.hitBlockChance > 0 && RandomUtils.randomIntInRange(1, 100) <= cfg.hitBlockChance) {
+                    performHitBlock(now, cfg)
+                }
+            }
+            1 -> { // Cooldown hits
+                if (now - hbLastHitAt > 2000) {
+                    hbHitsSince = 0
+                    hbTargetHits = 0
+                }
+                hbHitsSince++
+                if (allowed) {
+                    if (hbTargetHits == 0) {
+                        hbTargetHits = RandomUtils.randomIntInRange(cfg.hitBlockMinHits, cfg.hitBlockMaxHits)
+                    }
+                    if (hbHitsSince >= hbTargetHits) {
+                        performHitBlock(now, cfg)
+                        hbHitsSince = 0
+                        hbTargetHits = 0
+                    }
+                }
+            }
+        }
+        hbLastHitAt = now
+    }
+
     fun onPacket(packet: Packet<*>) {
         if (toggled) {
             when (packet) {
@@ -130,6 +188,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                                 combo++
                                 opponentCombo = 0
                                 ticksSinceHit = 0
+                                maybeHitBlock()
                             } else if (mc.thePlayer != null && entity.entityId == mc.thePlayer.entityId) {
                                 onAttacked()
                                 combo = 0
@@ -444,6 +503,10 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
         ticksSinceHit = 0
         ticksSinceGameStart = 0
         resultCounted = false
+        hbNextAllowedAt = 0L
+        hbHitsSince = 0
+        hbTargetHits = 0
+        hbLastHitAt = 0L
     }
 
     private fun gameStart() {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Blitz.kt
@@ -2,6 +2,7 @@ package best.spaghetcodes.kira.bot.bots
 
 import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.MovePriority
+import best.spaghetcodes.kira.bot.features.HitBlock
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
@@ -11,7 +12,7 @@ import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 
-class Blitz : BotBase("/play duels_blitz_duel"), MovePriority {
+class Blitz : BotBase("/play duels_blitz_duel"), MovePriority, HitBlock {
 
     override fun getName(): String = "Blitz"
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -4,6 +4,7 @@ import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.Bow
 import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.features.Rod
+import best.spaghetcodes.kira.bot.features.HitBlock
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
@@ -16,7 +17,7 @@ import net.minecraft.util.Vec3
 import kotlin.math.abs
 import kotlin.math.max
 
-class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
+class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority, HitBlock {
 
     override fun getName(): String = "Classic"
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -4,6 +4,7 @@ import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.Bow
 import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.features.Rod
+import best.spaghetcodes.kira.bot.features.HitBlock
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
@@ -16,7 +17,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
-class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
+class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority, HitBlock {
 
     override fun getName(): String = "ClassicV2"
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Combo.kt
@@ -4,6 +4,7 @@ import best.spaghetcodes.kira.bot.BotBase
 import best.spaghetcodes.kira.bot.features.Gap
 import best.spaghetcodes.kira.bot.features.MovePriority
 import best.spaghetcodes.kira.bot.features.Potion
+import best.spaghetcodes.kira.bot.features.HitBlock
 import best.spaghetcodes.kira.bot.player.Combat
 import best.spaghetcodes.kira.bot.player.Inventory
 import best.spaghetcodes.kira.bot.player.Mouse
@@ -18,7 +19,7 @@ import net.minecraft.init.Items
 import net.minecraft.potion.Potion as MCPotion
 import net.minecraft.util.Vec3
 
-class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion {
+class Combo : BotBase("/play duels_combo_duel"), MovePriority, Gap, Potion, HitBlock {
 
     // ---- State ----
     private var gameStartAt = 0L

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -12,7 +12,7 @@ import best.spaghetcodes.kira.utils.*
 import net.minecraft.init.Blocks
 import net.minecraft.util.Vec3
 
-class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
+class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, HitBlock {
 
     override fun getName(): String = "OP"
 

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/HitBlock.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/HitBlock.kt
@@ -1,0 +1,5 @@
+package best.spaghetcodes.kira.bot.features
+
+/** Marker interface for bots supporting the Hit & Block mechanic. */
+interface HitBlock
+

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -63,15 +63,15 @@ object Mouse {
     // --------------------------------------------
 
     fun leftClick() {
+        val mc = kira.mc
+        val player = mc.thePlayer ?: return
         if (kira.bot?.toggled() == true &&
             kira.config?.kiraHit == true &&
-            kira.mc.thePlayer != null &&
-            !kira.mc.thePlayer.isUsingItem) {
-            kira.mc.thePlayer.swingItem()
-            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindAttack.keyCode, true)
-            if (kira.mc.objectMouseOver != null && kira.mc.objectMouseOver.entityHit != null) {
-                kira.mc.playerController.attackEntity(kira.mc.thePlayer, kira.mc.objectMouseOver.entityHit)
-            }
+            !player.isUsingItem) {
+            val target = mc.objectMouseOver?.entityHit ?: return
+            player.swingItem()
+            KeyBinding.setKeyBindState(mc.gameSettings.keyBindAttack.keyCode, true)
+            mc.playerController.attackEntity(player, target)
         }
     }
 

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -72,6 +72,30 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Kira Hit", description = "Automatically attack opponents.", category = "Combat")
     var kiraHit = true
 
+    @Property(type = PropertyType.SWITCH, name = "Hit & Block", description = "Briefly block after successful sword hits.", category = "Combat")
+    var hitBlock = false
+
+    @Property(
+        type = PropertyType.SELECTOR,
+        name = "Hit & Block Mode",
+        description = "How Hit & Block triggers.",
+        category = "Combat",
+        options = ["Chance", "Cooldown Hits"]
+    )
+    var hitBlockMode = 0
+
+    @Property(type = PropertyType.NUMBER, name = "Hit & Block Min Interval", description = "Minimum interval between Hit & Block actions (ms).", category = "Combat", min = 0, max = 2000, increment = 10)
+    var hitBlockMinInterval = 0
+
+    @Property(type = PropertyType.NUMBER, name = "Hit & Block Chance", description = "Percentage chance for Hit & Block when in Chance mode.", category = "Combat", min = 0, max = 100, increment = 1)
+    var hitBlockChance = 0
+
+    @Property(type = PropertyType.NUMBER, name = "Hit & Block Min Hits", description = "Minimum successful hits before Hit & Block when in Cooldown mode.", category = "Combat", min = 1, max = 10, increment = 1)
+    var hitBlockMinHits = 2
+
+    @Property(type = PropertyType.NUMBER, name = "Hit & Block Max Hits", description = "Maximum successful hits before Hit & Block when in Cooldown mode.", category = "Combat", min = 1, max = 10, increment = 1)
+    var hitBlockMaxHits = 4
+
     @Property(type = PropertyType.SWITCH, name = "Enable AutoGG", description = "Send a gg message after every game", category = "AutoGG")
     var sendAutoGG = true
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -299,6 +299,31 @@ class CustomConfigGUI : GuiScreen() {
         number("Max Attack Distance", x, y, { cfg.maxDistanceAttack }, { cfg.maxDistanceAttack = it }, 3, 6, 1); y += 20
         toggle("Kira Hit", x, y, { cfg.kiraHit }, { cfg.kiraHit = it }); y += 24
 
+        toggle("Hit & Block", x, y, { cfg.hitBlock }, { cfg.hitBlock = it }); y += 24
+        selector(
+            "H&B Mode",
+            x,
+            y,
+            { cfg.hitBlockMode },
+            { cfg.hitBlockMode = it },
+            listOf("Chance", "Cooldown Hits")
+        );
+        y += 24
+        number(
+            "H&B Min Interval (ms)",
+            x,
+            y,
+            { cfg.hitBlockMinInterval },
+            { cfg.hitBlockMinInterval = it },
+            0,
+            2000,
+            10
+        );
+        y += 20
+        number("H&B Chance (%)", x, y, { cfg.hitBlockChance }, { cfg.hitBlockChance = it }, 0, 100, 1); y += 20
+        number("H&B Min Hits", x, y, { cfg.hitBlockMinHits }, { cfg.hitBlockMinHits = it }, 1, 10, 1); y += 20
+        number("H&B Max Hits", x, y, { cfg.hitBlockMaxHits }, { cfg.hitBlockMaxHits = it }, 1, 10, 1); y += 24
+
         // Option Boxing Fish dans l’onglet Combat
         toggle("Boxing: Use Fish", x, y, { cfg.boxingFish }, { cfg.boxingFish = it }); y += 20
 


### PR DESCRIPTION
## Summary
- add Hit & Block settings allowing chance-based or hit-count triggers
- expose Hit & Block controls in combat config UI
- perform brief right-click after sword hits for supported bots
- mark Classic, ClassicV2, Combo, OP, and Blitz as Hit & Block capable
- stop auto-clicker from swinging when no entity is targeted

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c30499ab288329b4e7674b2d368c36