### PR TITLE
Respect attack distance for auto click

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Mouse.kt
@@ -132,7 +132,14 @@ object Mouse {
 
     private fun leftACFunc() {
         if (kira.bot?.toggled() == true && leftAC && kira.config?.kiraHit == true) {
-            if (!kira.mc.thePlayer.isUsingItem) {
+            val player = kira.mc.thePlayer
+            val target = kira.bot?.opponent()
+            val maxDist = (kira.config?.maxDistanceAttack ?: 4).toFloat()
+
+            if (player != null && target != null &&
+                EntityUtils.getDistanceNoY(player, target) <= maxDist &&
+                !player.isUsingItem
+            ) {
                 val minCPS = kira.config?.minCPS ?: 10
                 val maxCPS = kira.config?.maxCPS ?: 14
 


### PR DESCRIPTION
## Summary
- avoid continuous hitting by limiting auto-click to the configured attack distance

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy / plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32543e458832985f93821fdee1b15