### PR TITLE
Fix Hit & Block in classic modes

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -67,6 +67,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     private var hbHitsSince = 0
     private var hbTargetHits = 0
     private var hbLastHitAt = 0L
+    protected var hbActiveUntil = 0L
 
     private var reconnectTimer: Timer? = null
 
@@ -129,6 +130,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
     private fun performHitBlock(now: Long, cfg: Config) {
         val dur = RandomUtils.randomIntInRange(40, 80)
         val delay = RandomUtils.randomIntInRange(0, 20)
+        hbActiveUntil = now + delay + dur
         TimeUtils.setTimeout({ Mouse.rClick(dur) }, delay)
         val interval = (cfg.hitBlockMinInterval + RandomUtils.randomIntInRange(-20, 20)).coerceAtLeast(0)
         hbNextAllowedAt = now + interval

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -294,6 +294,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         }
 
         val now = System.currentTimeMillis()
+        val hbActive = now < hbActiveUntil
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val approaching = (prevDistance > 0f) && (prevDistance - distance >= 0.15f)
 
@@ -347,19 +348,21 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         // Parade épée (sticky) + ne pas bloquer la rod prioritaire
         if (holdingSword) {
             if (Mouse.rClickDown) {
-                if (distance < 4.0f && !EntityUtils.entityFacingAway(p, opp)) {
-                    Mouse.rClickUp()
-                }
-                val movingHard = (!isStill && !(oppHasBow && bowSlowFrames >= bowSlowFramesNeeded)) || approaching
-                val mustKeep = (parryFromBow && now < parryExtendedUntil)
-                if (!mustKeep && (movingHard || now >= holdBlockUntil)) {
-                    val stopNow = RandomUtils.randomIntInRange(0, 99) < 80
-                    if (stopNow) {
+                if (!hbActive) {
+                    if (distance < 4.0f && !EntityUtils.entityFacingAway(p, opp)) {
                         Mouse.rClickUp()
-                        parryFromBow = false
-                        parryExtendedUntil = 0L
-                    } else {
-                        holdBlockUntil = max(holdBlockUntil, now + RandomUtils.randomIntInRange(120, 300))
+                    }
+                    val movingHard = (!isStill && !(oppHasBow && bowSlowFrames >= bowSlowFramesNeeded)) || approaching
+                    val mustKeep = (parryFromBow && now < parryExtendedUntil)
+                    if (!mustKeep && (movingHard || now >= holdBlockUntil)) {
+                        val stopNow = RandomUtils.randomIntInRange(0, 99) < 80
+                        if (stopNow) {
+                            Mouse.rClickUp()
+                            parryFromBow = false
+                            parryExtendedUntil = 0L
+                        } else {
+                            holdBlockUntil = max(holdBlockUntil, now + RandomUtils.randomIntInRange(120, 300))
+                        }
                     }
                 }
             } else {
@@ -396,7 +399,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
                 }
             }
         } else {
-            if (Mouse.rClickDown && !projectileActive) {
+            if (Mouse.rClickDown && !projectileActive && !hbActive) {
                 Mouse.rClickUp()
             }
             parryFromBow = false

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -445,6 +445,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         }
 
         val now = System.currentTimeMillis()
+        val hbActive = now < hbActiveUntil
         val distance = EntityUtils.getDistanceNoY(p, opp)
         val approaching = (prevDistance > 0f) && (prevDistance - distance >= 0.15f)
 
@@ -535,7 +536,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         val bowLikely = oppHasBowNow && (isStillNow || bowSlowFrames >= bowSlowFramesNeeded)
 
         // Close cancel strict (< 15) + verrou court
-        if (Mouse.rClickDown && distance < parryCloseCancelDist) {
+        if (Mouse.rClickDown && distance < parryCloseCancelDist && !hbActive) {
             Mouse.rClickUp()
             parryFromBow = false
             parryExtendedUntil = 0L
@@ -588,14 +589,14 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
                 }
 
                 val mustKeep = parryFromBow && now < parryExtendedUntil
-                if (!mustKeep && now >= holdBlockUntil) {
+                if (!mustKeep && now >= holdBlockUntil && !hbActive) {
                     Mouse.rClickUp()
                     parryFromBow = false
                     parryExtendedUntil = 0L
                 }
             }
         } else {
-            if (Mouse.rClickDown && !projectileActive) Mouse.rClickUp()
+            if (Mouse.rClickDown && !projectileActive && !hbActive) Mouse.rClickUp()
             parryFromBow = false
             parryExtendedUntil = 0L
         }


### PR DESCRIPTION
## Summary
- track active Hit & Block window to prevent immediate unblock
- honor Hit & Block in Classic and ClassicV2

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c332a452a08329ba4898bc764fbd3b