### PR TITLE
Remove Hit & Block min interval option

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -127,13 +127,12 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
 
     // ----------------------------------------------------
 
-    private fun performHitBlock(now: Long, cfg: Config) {
+    private fun performHitBlock(now: Long) {
         val dur = RandomUtils.randomIntInRange(40, 80)
         val delay = RandomUtils.randomIntInRange(0, 20)
         hbActiveUntil = now + delay + dur
         TimeUtils.setTimeout({ Mouse.rClick(dur) }, delay)
-        val interval = (cfg.hitBlockMinInterval + RandomUtils.randomIntInRange(-20, 20)).coerceAtLeast(0)
-        hbNextAllowedAt = now + interval
+        hbNextAllowedAt = now
     }
 
     private fun maybeHitBlock() {
@@ -152,7 +151,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
         when (cfg.hitBlockMode) {
             0 -> { // Chance
                 if (allowed && cfg.hitBlockChance > 0 && RandomUtils.randomIntInRange(1, 100) <= cfg.hitBlockChance) {
-                    performHitBlock(now, cfg)
+                    performHitBlock(now)
                 }
             }
             1 -> { // Cooldown hits
@@ -166,7 +165,7 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
                         hbTargetHits = RandomUtils.randomIntInRange(cfg.hitBlockMinHits, cfg.hitBlockMaxHits)
                     }
                     if (hbHitsSince >= hbTargetHits) {
-                        performHitBlock(now, cfg)
+                        performHitBlock(now)
                         hbHitsSince = 0
                         hbTargetHits = 0
                     }

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -84,9 +84,6 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     )
     var hitBlockMode = 0
 
-    @Property(type = PropertyType.NUMBER, name = "Hit & Block Min Interval", description = "Minimum interval between Hit & Block actions (ms).", category = "Combat", min = 0, max = 2000, increment = 10)
-    var hitBlockMinInterval = 0
-
     @Property(type = PropertyType.NUMBER, name = "Hit & Block Chance", description = "Percentage chance for Hit & Block when in Chance mode.", category = "Combat", min = 0, max = 100, increment = 1)
     var hitBlockChance = 0
 

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -309,17 +309,6 @@ class CustomConfigGUI : GuiScreen() {
             listOf("Chance", "Cooldown Hits")
         );
         y += 24
-        number(
-            "H&B Min Interval (ms)",
-            x,
-            y,
-            { cfg.hitBlockMinInterval },
-            { cfg.hitBlockMinInterval = it },
-            0,
-            2000,
-            10
-        );
-        y += 20
         number("H&B Chance (%)", x, y, { cfg.hitBlockChance }, { cfg.hitBlockChance = it }, 0, 100, 1); y += 20
         number("H&B Min Hits", x, y, { cfg.hitBlockMinHits }, { cfg.hitBlockMinHits = it }, 1, 10, 1); y += 20
         number("H&B Max Hits", x, y, { cfg.hitBlockMaxHits }, { cfg.hitBlockMaxHits = it }, 1, 10, 1); y += 24


### PR DESCRIPTION
## Summary
- remove Hit & Block min interval setting from config and GUI
- simplify hit-block logic to trigger without enforced delay

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" for com.mojang:minecraft:1.8.9)*

------
https://chatgpt.com/codex/tasks/task_e_68c345195adc83298e555f8f11fd7e8a