### PR TITLE
feat: turn around when lobby movement hits wall

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -48,10 +48,9 @@ object LobbyMovement {
 
             intervals.add(TimeUtils.setInterval(
                 fun () {
-                    tickYawChange = if (WorldUtils.airInFront(kira.mc.thePlayer, 4f)) {
-                        RandomUtils.randomDoubleInRange(-13.0, 13.0).toFloat()
-                    } else {
-                        0f
+                    val player = kira.mc.thePlayer
+                    if (player != null && !WorldUtils.airInFront(player, 1f)) {
+                        player.rotationYaw += 180f
                     }
                 },
                 0,


### PR DESCRIPTION
## Summary
- Reverse direction instead of drifting sideways when the lobby bot runs into a wall

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68c3db10542c8329b9c94f1bd18301ae