### PR TITLE
Allow rod to override hit and block

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/Classic.kt
@@ -253,11 +253,15 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
 
         // 1) clic principal
         if (delay == 0) {
+            if (Mouse.rClickDown) Mouse.rClickUp()
             Mouse.rClick(clickMs)
         } else {
             actionLockUntil += 50
             projectileGraceUntil += 50
-            TimeUtils.setTimeout({ Mouse.rClick(clickMs) }, 50)
+            TimeUtils.setTimeout({
+                if (Mouse.rClickDown) Mouse.rClickUp()
+                Mouse.rClick(clickMs)
+            }, 50)
         }
 
         // 2) backup click APRÈS la fin du clic principal
@@ -421,7 +425,7 @@ class Classic : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         }
 
         // ---------------- Fenêtres rod / bow ----------------
-        if (!projectileActive && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && !Mouse.rClickDown) {
+        if (!projectileActive && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && (!Mouse.rClickDown || hbActive)) {
 
             // reset fenêtre quota rods
             if (now > rodWindowResetAt) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/ClassicV2.kt
@@ -337,6 +337,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
             val nowClick = System.currentTimeMillis()
 
             Mouse.setUsingProjectile(true)
+            if (Mouse.rClickDown) Mouse.rClickUp()
             Mouse.rClick(RandomUtils.randomIntInRange(70, 95))
             reentryRodGraceUntil = 0L
 
@@ -628,7 +629,7 @@ class ClassicV2 : BotBase("/play duels_classic_duel"), Bow, Rod, MovePriority {
         if ((!projectileActive || now < reentryRodGraceUntil) &&
             !Mouse.isRunningAway() &&
             !Mouse.isUsingPotion() &&
-            (!Mouse.rClickDown || now < reentryRodGraceUntil)) {
+            (!Mouse.rClickDown || hbActive || now < reentryRodGraceUntil)) {
 
             // *** BAN ROD en zone de mêlée : ne pas sortir la rod ≤ 4.0 blocs ***
             if (distance <= rodBanMeleeDist) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -288,6 +288,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             }
 
             val now = System.currentTimeMillis()
+            val hbActive = now < hbActiveUntil
             if (((distance > 3f && mc.thePlayer.health < 12) || mc.thePlayer.health < 9) &&
                 combo < 2 && mc.thePlayer.health <= opponent()!!.health) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
@@ -311,7 +312,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
                 }
             }
 
-            if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && !Mouse.rClickDown &&
+            if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() && (!Mouse.rClickDown || hbActive) &&
                 !eatingGap && System.currentTimeMillis() - lastGap > 2500) {
 
                 if ((distance in 5.7f..6.5f || distance in 9.0f..9.5f) &&

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Rod.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Rod.kt
@@ -37,6 +37,7 @@ interface Rod {
             }
 
             // Clic droit bref → lance la ligne
+            if (Mouse.rClickDown) Mouse.rClickUp()
             Mouse.rClick(clickMs)
 
             // Revenir épée après un petit temps de vol
@@ -64,6 +65,7 @@ interface Rod {
 
         // Switch instant + clic droit immédiat
         Inventory.setInvItem("rod")
+        if (Mouse.rClickDown) Mouse.rClickUp()
         Mouse.rClick(clickMs)
 
         // Retour épée après court temps de vol


### PR DESCRIPTION
## Summary
- Make rod casting cancel active Hit & Block right-click before firing
- Permit rod usage while Hit & Block is active across Classic, ClassicV2, and OP bots
- Guard rod utilities to release right-click if already held

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c4053e7760832994d5782a5d0a94a1