### PR TITLE
fix: retain session start on bot reactivation

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/BotBase.kt
@@ -342,7 +342,9 @@ open class BotBase(val queueCommand: String, val quickRefresh: Int = 10000) {
             if (toggled()) {
                 ChatUtils.info("Current selected bot: ${EnumChatFormatting.GREEN}${getName()}")
                 joinGame()
-                Session.startTime = System.currentTimeMillis()
+                if (Session.startTime <= 0L) {
+                    Session.startTime = System.currentTimeMillis()
+                }
                 resultCounted = false
             }
         }


### PR DESCRIPTION
## Summary
- prevent session start time from resetting every time bot toggles on

## Testing
- `./gradlew test` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c4509f6cac83299dfc88f35ebcf7ac