### PR TITLE
Add lobby movement mode selector

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
@@ -27,11 +27,14 @@ object StateManager {
         val unformatted = ev.message.unformattedText
         if (unformatted.matches(Regex(".* a rejoint \\(./2\\)!"))) {
             state = States.GAME
-            if (kira.bot is Sumo) {
-                LobbyMovement.startMovement(Config.LobbyMovementType.SUMO)
-            } else {
-                LobbyMovement.startMovement(Config.LobbyMovementType.RANDOM_MOVES)
-            }
+            val moveType =
+                if (kira.bot is Sumo) {
+                    Config.LobbyMovementType.SUMO
+                } else {
+                    val idx = kira.config?.lobbyMovementMode ?: 0
+                    Config.LobbyMovementType.values().getOrElse(idx) { Config.LobbyMovementType.RANDOM_MOVES }
+                }
+            LobbyMovement.startMovement(moveType)
             if (unformatted.matches(Regex(".* a rejoint \\(2/2\\)!"))) {
                 gameFull = true
             }
@@ -43,11 +46,14 @@ object StateManager {
             state = States.GAME
             gameFull = false
             lastGameDuration = System.currentTimeMillis() - gameStartedAt
-            if (kira.bot is Sumo) {
-                LobbyMovement.startMovement(Config.LobbyMovementType.SUMO)
-            } else {
-                LobbyMovement.startMovement(Config.LobbyMovementType.RANDOM_MOVES)
-            }
+            val moveType =
+                if (kira.bot is Sumo) {
+                    Config.LobbyMovementType.SUMO
+                } else {
+                    val idx = kira.config?.lobbyMovementMode ?: 0
+                    Config.LobbyMovementType.values().getOrElse(idx) { Config.LobbyMovementType.RANDOM_MOVES }
+                }
+            LobbyMovement.startMovement(moveType)
         } else if (unformatted.contains("has quit!")) {
             gameFull = false
         }

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -33,6 +33,15 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Lobby Movement", description = "Whether or not the bot should move in pre-game lobbies.", category = "General")
     var lobbyMovement = true
 
+    @Property(
+        type = PropertyType.SELECTOR,
+        name = "Lobby Movement Mode",
+        description = "Movement pattern to use in pre-game lobbies.",
+        category = "General",
+        options = ["Random Moves", "Strafe Walk", "Walker", "Slow Drift", "Fast Forward"]
+    )
+    var lobbyMovementMode = 0
+
     @Property(type = PropertyType.SWITCH, name = "Disable Chat Messages", description = "When this is enabled, the bot will not send any chat messages.", category = "General")
     var disableChatMessages = false
 
@@ -188,6 +197,7 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
         addDependency("dodgeWLR", "enableDodging")
         addDependency("dodgeLostTo", "enableDodging")
         addDependency("dodgeNoStats", "enableDodging")
+        addDependency("lobbyMovementMode", "lobbyMovement")
 
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -250,6 +250,15 @@ class CustomConfigGUI : GuiScreen() {
         }, botNames); y += 24
 
         toggle("Lobby Movement", x, y, { cfg.lobbyMovement }, { cfg.lobbyMovement = it }); y += 20
+        selector(
+            "Lobby Move Mode",
+            x,
+            y,
+            { cfg.lobbyMovementMode },
+            { cfg.lobbyMovementMode = it },
+            listOf("Random Moves", "Strafe Walk", "Walker", "Slow Drift", "Fast Forward")
+        );
+        y += 24
         toggle("Fast Requeue", x, y, { cfg.fastRequeue }, { cfg.fastRequeue = it }); y += 20
         toggle("Paper Requeue", x, y, { cfg.paperRequeue }, { cfg.paperRequeue = it }); y += 20
         toggle("Disable Chat Messages", x, y, { cfg.disableChatMessages }, { cfg.disableChatMessages = it }); y += 24


### PR DESCRIPTION
## Summary
- expose lobby movement mode in configuration UI
- store selected movement mode in config with dependency on toggle
- start lobby movement using selected mode

## Testing
- `./gradlew build` *(fails: Failed to provide com.mojang:minecraft:1.8.9 : java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"))*

------
https://chatgpt.com/codex/tasks/task_e_68c45849d7a88329a7e61d785451e049