### PR TITLE
Simplify lobby movement system

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/StateManager.kt
@@ -31,8 +31,7 @@ object StateManager {
                 if (kira.bot is Sumo) {
                     Config.LobbyMovementType.SUMO
                 } else {
-                    val idx = kira.config?.lobbyMovementMode ?: 0
-                    Config.LobbyMovementType.values().getOrElse(idx) { Config.LobbyMovementType.RANDOM_MOVES }
+                    Config.LobbyMovementType.FAST_FORWARD
                 }
             LobbyMovement.startMovement(moveType)
             if (unformatted.matches(Regex(".* a rejoint \\(2/2\\)!"))) {
@@ -50,8 +49,7 @@ object StateManager {
                 if (kira.bot is Sumo) {
                     Config.LobbyMovementType.SUMO
                 } else {
-                    val idx = kira.config?.lobbyMovementMode ?: 0
-                    Config.LobbyMovementType.values().getOrElse(idx) { Config.LobbyMovementType.RANDOM_MOVES }
+                    Config.LobbyMovementType.FAST_FORWARD
                 }
             LobbyMovement.startMovement(moveType)
         } else if (unformatted.contains("has quit!")) {

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -4,8 +4,6 @@ import best.spaghetcodes.kira.core.Config
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.RandomUtils
 import best.spaghetcodes.kira.utils.TimeUtils
-import best.spaghetcodes.kira.utils.WorldUtils
-import net.minecraft.util.BlockPos
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
 import java.util.*
@@ -29,13 +27,11 @@ object LobbyMovement {
             return
         }
 
-        if (activeMovementType == typeToStart && typeToStart != Config.LobbyMovementType.FAST_FORWARD) {
-            return
-        }
-
-        if (activeMovementType == typeToStart && typeToStart == Config.LobbyMovementType.FAST_FORWARD) {
-            if (kira.mc.thePlayer?.onGround == true && !Movement.jumping()) {
-                Movement.startJumping()
+        if (activeMovementType == typeToStart) {
+            if (typeToStart == Config.LobbyMovementType.FAST_FORWARD) {
+                if (kira.mc.thePlayer?.onGround == true && !Movement.jumping()) {
+                    Movement.startJumping()
+                }
             }
             return
         }
@@ -47,24 +43,6 @@ object LobbyMovement {
 
     private fun internalStartMovementLogic(type: Config.LobbyMovementType) {
         when (type) {
-            Config.LobbyMovementType.RANDOM_MOVES -> {
-                val availableMovements = Config.LobbyMovementType.values().filter {
-                    it != Config.LobbyMovementType.RANDOM_MOVES
-                }
-
-                if (availableMovements.isNotEmpty()) {
-                    val randomChoice = availableMovements[RandomUtils.randomIntInRange(0, availableMovements.size - 1)]
-                    activeMovementType = randomChoice
-                    internalStartMovementLogic(randomChoice)
-                } else {
-                    activeMovementType = Config.LobbyMovementType.STRAFE_WALK
-                    circleStrafeInternal()
-                }
-            }
-
-            Config.LobbyMovementType.STRAFE_WALK -> circleStrafeInternal()
-            Config.LobbyMovementType.WALKER -> walkerInternal()
-            Config.LobbyMovementType.SLOW_DRIFT -> shiftWalkerInternal()
             Config.LobbyMovementType.FAST_FORWARD -> runForwardPreGameInternal()
             Config.LobbyMovementType.SUMO -> sumoInternal()
         }
@@ -99,125 +77,6 @@ object LobbyMovement {
         }, RandomUtils.randomIntInRange(300, 500), RandomUtils.randomIntInRange(300, 500)))
     }
 
-    private fun circleStrafeInternal() {
-        Movement.startForward()
-        if (RandomUtils.randomBool()) Movement.startSprinting()
-        desiredPitch = 0f
-        val circleYawSpeed = RandomUtils.randomDoubleInRange(3.5, 6.5).toFloat()
-        tickYawChange = if (RandomUtils.randomBool()) circleYawSpeed else -circleYawSpeed
-
-        var strafingLeft = RandomUtils.randomBool()
-        if (strafingLeft) Movement.startLeft() else Movement.startRight()
-
-        intervals.add(TimeUtils.setInterval(fun() {
-            if (kira.mc.thePlayer == null || activeMovementType != Config.LobbyMovementType.STRAFE_WALK) return@setInterval
-            strafingLeft = !strafingLeft
-            if (strafingLeft) { Movement.stopRight(); Movement.startLeft() } else { Movement.stopLeft(); Movement.startRight() }
-            if (RandomUtils.randomIntInRange(0, 2) == 0) tickYawChange *= -1
-        }, RandomUtils.randomIntInRange(1500, 3500), RandomUtils.randomIntInRange(1500, 3500)))
-
-        intervals.add(TimeUtils.setInterval(fun() {
-            if (kira.mc.thePlayer?.onGround == true && activeMovementType == Config.LobbyMovementType.STRAFE_WALK) {
-                if (RandomUtils.randomIntInRange(0, 2) == 0) Movement.singleJump(RandomUtils.randomIntInRange(70, 130))
-            }
-        }, RandomUtils.randomIntInRange(1000, 2500), RandomUtils.randomIntInRange(1000, 2500)))
-    }
-
-    private fun walkerInternal() {
-        Movement.startForward()
-        if (RandomUtils.randomBool()) Movement.startSprinting()
-        desiredPitch = RandomUtils.randomDoubleInRange(-10.0, 10.0).toFloat()
-        tickYawChange = 0f
-        var preferredSideIsLeft = RandomUtils.randomBool()
-        val wallCheckDistance = 1.0f
-        val turnStrength = RandomUtils.randomDoubleInRange(6.0, 12.0).toFloat()
-        val sharpTurnStrength = RandomUtils.randomDoubleInRange(20.0, 30.0).toFloat()
-
-        intervals.add(TimeUtils.setInterval(fun() {
-            val player = kira.mc.thePlayer ?: return@setInterval
-            if (activeMovementType != Config.LobbyMovementType.WALKER) return@setInterval
-
-            if (!WorldUtils.airInFront(player, 0.6f)) {
-                tickYawChange = (if (preferredSideIsLeft) 1 else -1) * sharpTurnStrength
-                Movement.clearLeftRight(); return@setInterval
-            }
-            val (wallOnPreferredSide, wallOnOppositeSide) = if (preferredSideIsLeft) Pair(!WorldUtils.airOnLeft(player, wallCheckDistance), !WorldUtils.airOnRight(player, wallCheckDistance)) else Pair(!WorldUtils.airOnRight(player, wallCheckDistance), !WorldUtils.airOnLeft(player, wallCheckDistance))
-            if (wallOnPreferredSide) {
-                Movement.clearLeftRight()
-                tickYawChange = (if (preferredSideIsLeft) 1 else -1) * RandomUtils.randomDoubleInRange(1.0, 3.0).toFloat()
-                val veryCloseDist = 0.3f
-                val isVeryClose = if (preferredSideIsLeft) !WorldUtils.airOnLeft(player, veryCloseDist) else !WorldUtils.airOnRight(player, veryCloseDist)
-                if (isVeryClose) tickYawChange = (if (preferredSideIsLeft) 1 else -1) * (turnStrength + 3f)
-            } else {
-                tickYawChange = (if (preferredSideIsLeft) -1 else 1) * turnStrength
-                if (wallOnOppositeSide) preferredSideIsLeft = !preferredSideIsLeft
-                else tickYawChange = RandomUtils.randomDoubleInRange(-sharpTurnStrength / 1.5, sharpTurnStrength / 1.5).toFloat()
-            }
-        }, RandomUtils.randomIntInRange(70, 180), RandomUtils.randomIntInRange(70, 180)))
-    }
-
-    private fun shiftWalkerInternal() {
-        Movement.startSneaking()
-        Movement.startForward()
-        desiredPitch = RandomUtils.randomDoubleInRange(45.0, 75.0).toFloat()
-        tickYawChange = 0f
-        var currentAction = "walking_slow"
-        var targetYaw = kira.mc.thePlayer?.rotationYaw ?: 0f
-
-        intervals.add(TimeUtils.setInterval(fun() {
-            val player = kira.mc.thePlayer ?: return@setInterval
-            if (activeMovementType != Config.LobbyMovementType.SLOW_DRIFT) return@setInterval
-
-            desiredPitch = RandomUtils.randomDoubleInRange(40.0, 80.0).toFloat()
-
-            val lookVec = player.lookVec
-            val checkX = player.posX + lookVec.xCoord * 0.8
-            val checkZ = player.posZ + lookVec.zCoord * 0.8
-            val checkY = player.posY - 1
-            val blockAheadBelow = kira.mc.theWorld.getBlockState(BlockPos(checkX, checkY, checkZ)).block
-
-            if (blockAheadBelow.material.isReplaceable || !WorldUtils.airInFront(player, 0.6f)) {
-                val deltaYaw = RandomUtils.randomDoubleInRange(60.0, 120.0) * (if (RandomUtils.randomBool()) 1 else -1)
-                targetYaw += deltaYaw.toFloat()
-                Movement.stopForward()
-                TimeUtils.setTimeout(fun() {
-                    if (activeMovementType == Config.LobbyMovementType.SLOW_DRIFT && currentAction == "walking_slow")
-                        Movement.startForward()
-                }, 600)
-                return@setInterval
-            }
-
-            val actionChoice = RandomUtils.randomIntInRange(0, 10)
-            when {
-                actionChoice < 8 -> {
-                    if (currentAction != "walking_slow" || !Movement.forward()) {
-                        Movement.clearLeftRight(); Movement.stopBackward(); Movement.startForward(); currentAction = "walking_slow"
-                    }
-
-                    val yawWiggle = RandomUtils.randomDoubleInRange(-5.0, 5.0).toFloat()
-                    targetYaw += yawWiggle
-                }
-                else -> {
-                    if (currentAction != "shuffling") {
-                        Movement.stopForward(); currentAction = "shuffling"
-                    }
-                    val dir = if (RandomUtils.randomBool()) Movement::startLeft else Movement::startRight
-                    val stopDir = if (dir == Movement::startLeft) Movement::stopLeft else Movement::stopRight
-                    dir.invoke()
-                    TimeUtils.setTimeout({ if (activeMovementType == Config.LobbyMovementType.SLOW_DRIFT) stopDir.invoke() }, RandomUtils.randomIntInRange(250, 550))
-                }
-            }
-        }, 1200, 1200))
-
-        intervals.add(TimeUtils.setInterval({
-            val player = kira.mc.thePlayer ?: return@setInterval
-            if (activeMovementType != Config.LobbyMovementType.SLOW_DRIFT) return@setInterval
-
-            val currentYaw = player.rotationYaw
-            val diff = ((targetYaw - currentYaw + 540) % 360) - 180
-            tickYawChange = (diff * 0.15f).coerceIn(-4f, 4f)
-        }, 50, 50))
-    }
 
 
 
@@ -232,19 +91,6 @@ object LobbyMovement {
 
     private fun maintainMovement() {
         when (activeMovementType) {
-            Config.LobbyMovementType.STRAFE_WALK -> {
-                if (!Movement.forward()) Movement.startForward()
-                if (!Movement.left() && !Movement.right()) {
-                    if (RandomUtils.randomBool()) Movement.startLeft() else Movement.startRight()
-                }
-            }
-            Config.LobbyMovementType.WALKER -> {
-                if (!Movement.forward()) Movement.startForward()
-            }
-            Config.LobbyMovementType.SLOW_DRIFT -> {
-                if (!Movement.sneaking()) Movement.startSneaking()
-                if (!Movement.forward() && !Movement.left() && !Movement.right()) Movement.startForward()
-            }
             Config.LobbyMovementType.FAST_FORWARD -> {
                 if (!Movement.forward()) Movement.startForward()
                 if (!Movement.sprinting()) Movement.startSprinting()

--- a/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/core/Config.kt
@@ -33,15 +33,6 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     @Property(type = PropertyType.SWITCH, name = "Lobby Movement", description = "Whether or not the bot should move in pre-game lobbies.", category = "General")
     var lobbyMovement = true
 
-    @Property(
-        type = PropertyType.SELECTOR,
-        name = "Lobby Movement Mode",
-        description = "Movement pattern to use in pre-game lobbies.",
-        category = "General",
-        options = ["Random Moves", "Strafe Walk", "Walker", "Slow Drift", "Fast Forward"]
-    )
-    var lobbyMovementMode = 0
-
     @Property(type = PropertyType.SWITCH, name = "Disable Chat Messages", description = "When this is enabled, the bot will not send any chat messages.", category = "General")
     var disableChatMessages = false
 
@@ -197,7 +188,6 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
         addDependency("dodgeWLR", "enableDodging")
         addDependency("dodgeLostTo", "enableDodging")
         addDependency("dodgeNoStats", "enableDodging")
-        addDependency("lobbyMovementMode", "lobbyMovement")
 
         // Toujours utiliser getBot ici -> pas d'Any
         registerListener("currentBot") { idx: Int ->
@@ -210,10 +200,6 @@ class Config : Vigilant(File(kira.configLocation), sortingBehavior = ConfigSorte
     fun getCustomGui(): GuiScreen = CustomConfigGUI()
 
     enum class LobbyMovementType {
-        RANDOM_MOVES,
-        STRAFE_WALK,
-        WALKER,
-        SLOW_DRIFT,
         FAST_FORWARD,
         SUMO
     }

--- a/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/gui/CustomConfigGUI.kt
@@ -250,15 +250,6 @@ class CustomConfigGUI : GuiScreen() {
         }, botNames); y += 24
 
         toggle("Lobby Movement", x, y, { cfg.lobbyMovement }, { cfg.lobbyMovement = it }); y += 20
-        selector(
-            "Lobby Move Mode",
-            x,
-            y,
-            { cfg.lobbyMovementMode },
-            { cfg.lobbyMovementMode = it },
-            listOf("Random Moves", "Strafe Walk", "Walker", "Slow Drift", "Fast Forward")
-        );
-        y += 24
         toggle("Fast Requeue", x, y, { cfg.fastRequeue }, { cfg.fastRequeue = it }); y += 20
         toggle("Paper Requeue", x, y, { cfg.paperRequeue }, { cfg.paperRequeue = it }); y += 20
         toggle("Disable Chat Messages", x, y, { cfg.disableChatMessages }, { cfg.disableChatMessages = it }); y += 24


### PR DESCRIPTION
## Summary
- Remove lobby movement mode selector and related unused modes
- Default to Fast Forward movement except for the Sumo bot
- Streamline lobby movement code to handle only Fast Forward and Sumo

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c4791b80388329b9cfc256cc48a5b9