### PR TITLE
Rotate bot 180° when fast forward movement hits a wall

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/LobbyMovement.kt
@@ -14,6 +14,7 @@ object LobbyMovement {
     private var desiredPitch: Float? = null
     private var intervals: ArrayList<Timer?> = ArrayList()
     private var activeMovementType: Config.LobbyMovementType? = null
+    private var collidedLastTick = false
 
     private fun canActivateAndRunAnyMovement(): Boolean {
         return kira.mc.thePlayer != null &&
@@ -87,6 +88,7 @@ object LobbyMovement {
         tickYawChange = 0f
         desiredPitch = null
         activeMovementType = null
+        collidedLastTick = false
     }
 
     private fun maintainMovement() {
@@ -95,7 +97,17 @@ object LobbyMovement {
                 if (!Movement.forward()) Movement.startForward()
                 if (!Movement.sprinting()) Movement.startSprinting()
                 val p = kira.mc.thePlayer
-                if (p != null && p.onGround && !Movement.jumping()) Movement.startJumping()
+                if (p != null) {
+                    if (p.isCollidedHorizontally) {
+                        if (!collidedLastTick) {
+                            p.rotationYaw += 180f
+                            collidedLastTick = true
+                        }
+                    } else {
+                        collidedLastTick = false
+                        if (p.onGround && !Movement.jumping()) Movement.startJumping()
+                    }
+                }
             }
             Config.LobbyMovementType.SUMO -> {
                 if (!Movement.forward()) Movement.startForward()


### PR DESCRIPTION
## Summary
- detect horizontal collision during fast forward lobby movement
- rotate the player 180° when blocked and resume jumping

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c47cb18fcc8329afcecc852018c74a