### PR TITLE
Restore Movement object for lobby motion control

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/player/Movement.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/player/Movement.kt
@@ -1,183 +1,173 @@
 package best.spaghetcodes.kira.bot.player
 
-import best.spaghetcodes.kira.core.Config
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.RandomUtils
 import best.spaghetcodes.kira.utils.TimeUtils
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent
-import java.util.*
+import net.minecraft.client.settings.KeyBinding
 
-// Mouvement de lobby : FAST_FORWARD (inchangé) et SUMO (cercle régulier)
+object Movement {
+    private var forward = false
+    private var backward = false
+    private var left = false
+    private var right = false
+    private var jumping = false
+    private var sprinting = false
+    private var sneaking = false
 
-object LobbyMovement {
-
-    // === commun ===
-    private var tickYawChange = 0f
-    private var desiredPitch: Float? = null
-    private var intervals: ArrayList<Timer?> = ArrayList()
-    private var activeMovementType: Config.LobbyMovementType? = null
-
-    private fun canActivateAndRunAnyMovement(): Boolean {
-        return kira.mc.thePlayer != null &&
-                kira.bot?.toggled() == true &&
-                kira.config?.lobbyMovement == true
-    }
-
-    fun startMovement(typeToStart: Config.LobbyMovementType) {
-        if (!canActivateAndRunAnyMovement()) {
-            if (activeMovementType != null) stop()
-            return
-        }
-        if (activeMovementType == typeToStart) {
-            // petit bonus pour FAST_FORWARD : s’assurer que ça saute si on est au sol
-            if (typeToStart == Config.LobbyMovementType.FAST_FORWARD) {
-                if (kira.mc.thePlayer?.onGround == true && !Movement.jumping()) {
-                    Movement.startJumping()
-                }
-            }
-            return
-        }
-        stop()
-        activeMovementType = typeToStart
-        internalStartMovementLogic(activeMovementType!!)
-    }
-
-    private fun internalStartMovementLogic(type: Config.LobbyMovementType) {
-        when (type) {
-            Config.LobbyMovementType.FAST_FORWARD -> runForwardPreGameInternal()
-            Config.LobbyMovementType.SUMO -> sumoInternal()
+    fun startForward() {
+        if (kira.bot?.toggled() == true) { // need to do this because the type is Boolean? so it could be null
+            forward = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindForward.keyCode, true)
         }
     }
 
-    // === FAST_FORWARD inchangé (exemple générique) ===
-    private fun runForwardPreGameInternal() {
-        Movement.startForward()
-        Movement.startSprinting()
-        Movement.startJumping()
-        tickYawChange = 0f
-        desiredPitch = 0f
-        // Ex : demi-tour toutes les 7 s
-        intervals.add(TimeUtils.setInterval(fun() {
-            val p = kira.mc.thePlayer ?: return@setInterval
-            p.rotationYaw += 180f
-        }, 7000, 7000))
-    }
-
-    // =========================
-    //         SUMO
-    // =========================
-
-    // Paramètres faciles à tuner
-    private const val SUMO_ANGLE_DEG = 45f               // pas angulaire
-    private const val SUMO_ROTATE_EVERY_JUMPS = 2        // tous les N sauts
-
-    // État Sumo
-    private var sumoInitialTurnRight = true              // sens du pivot initial
-    private var sumoCircleTurnRight = false              // sens du cercle (opposé au pivot initial)
-    private var sumoJumpCounter = 0                      // nb d’impulsions déclenchées
-    private var sumoWasOnGround = false                  // pour détecter l’atterrissage
-
-    private fun sumoInternal() {
-        val player = kira.mc.thePlayer ?: return
-
-        // petit pitch naturel
-        desiredPitch = RandomUtils.randomDoubleInRange(-5.0, 10.0).toFloat()
-
-        // 1) rotation initiale ±45°
-        sumoInitialTurnRight = RandomUtils.randomBool()
-        player.rotationYaw += if (sumoInitialTurnRight) SUMO_ANGLE_DEG else -SUMO_ANGLE_DEG
-
-        // 2) sens du cercle = opposé au pivot initial
-        sumoCircleTurnRight = !sumoInitialTurnRight
-
-        // 3) démarrer l’allure
-        Movement.startForward()
-        Movement.startSprinting()
-        tickYawChange = 0f
-        sumoJumpCounter = 0
-        sumoWasOnGround = player.onGround
-
-        // 4) premier saut immédiat après le pivot si on peut
-        if (player.onGround) {
-            Movement.singleJump(RandomUtils.randomIntInRange(80, 150))
-            sumoJumpCounter = 1
-        }
-
-        // NB : plus d’intervalle pour gérer les sauts → on travaille à l’atterrissage dans onClientTick()
-    }
-
-    private fun sumoTick() {
-        val p = kira.mc.thePlayer ?: return
-
-        // sécurité : maintenir la marche/sprint
-        if (!Movement.forward()) Movement.startForward()
-        if (!Movement.sprinting()) Movement.startSprinting()
-
-        // Détection d’atterrissage : onGround vient de passer de false -> true
-        val justLanded = p.onGround && !sumoWasOnGround
-        if (justLanded) {
-            // On prépare le prochain saut (léger délai pour fiabiliser)
-            Movement.singleJump(RandomUtils.randomIntInRange(80, 150))
-            sumoJumpCounter++
-
-            // Tous les N sauts, on rajoute ±45° dans le sens du cercle (opposé au pivot initial)
-            if (sumoJumpCounter % SUMO_ROTATE_EVERY_JUMPS == 0) {
-                p.rotationYaw += if (sumoCircleTurnRight) SUMO_ANGLE_DEG else -SUMO_ANGLE_DEG
-            }
-        }
-
-        sumoWasOnGround = p.onGround
-    }
-
-    fun stop() {
-        Movement.clearAll()
-        intervals.forEach { it?.cancel() }
-        intervals.clear()
-        tickYawChange = 0f
-        desiredPitch = null
-        activeMovementType = null
-
-        // reset état sumo
-        sumoJumpCounter = 0
-        sumoInitialTurnRight = true
-        sumoCircleTurnRight = false
-        sumoWasOnGround = false
-    }
-
-    private fun maintainMovement() {
-        when (activeMovementType) {
-            Config.LobbyMovementType.FAST_FORWARD -> {
-                if (!Movement.forward()) Movement.startForward()
-                if (!Movement.sprinting()) Movement.startSprinting()
-                val p = kira.mc.thePlayer
-                if (p != null && p.onGround && !Movement.jumping()) Movement.startJumping()
-            }
-            Config.LobbyMovementType.SUMO -> {
-                if (!Movement.forward()) Movement.startForward()
-                if (!Movement.sprinting()) Movement.startSprinting()
-            }
-            else -> {}
+    fun stopForward() {
+        if (kira.bot?.toggled() == true) {
+            forward = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindForward.keyCode, false)
         }
     }
 
-    @SubscribeEvent
-    fun onClientTick(event: ClientTickEvent) {
-        if (!canActivateAndRunAnyMovement()) {
-            if (activeMovementType != null) stop()
-            return
-        }
-
-        // “entretien” commun
-        maintainMovement()
-
-        // appli pitch/yaw
-        desiredPitch?.let { kira.mc.thePlayer!!.rotationPitch = it }
-        kira.mc.thePlayer!!.rotationYaw += tickYawChange
-
-        // boucle sumo par tick
-        if (activeMovementType == Config.LobbyMovementType.SUMO) {
-            sumoTick()
+    fun startBackward() {
+        if (kira.bot?.toggled() == true) {
+            backward = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindBack.keyCode, true)
         }
     }
+
+    fun stopBackward() {
+        if (kira.bot?.toggled() == true) {
+            backward = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindBack.keyCode, false)
+        }
+    }
+
+    fun startLeft() {
+        if (kira.bot?.toggled() == true) {
+            left = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindLeft.keyCode, true)
+        }
+    }
+
+    fun stopLeft() {
+        if (kira.bot?.toggled() == true) {
+            left = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindLeft.keyCode, false)
+        }
+    }
+
+    fun startRight() {
+        if (kira.bot?.toggled() == true) {
+            right = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindRight.keyCode, true)
+        }
+    }
+
+    fun stopRight() {
+        if (kira.bot?.toggled() == true) {
+            right = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindRight.keyCode, false)
+        }
+    }
+
+    fun startJumping() {
+        if (kira.bot?.toggled() == true) {
+            jumping = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindJump.keyCode, true)
+        }
+    }
+
+    fun stopJumping() {
+        if (kira.bot?.toggled() == true) {
+            jumping = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindJump.keyCode, false)
+        }
+    }
+
+    fun startSprinting() {
+        if (kira.bot?.toggled() == true) {
+            sprinting = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindSprint.keyCode, true)
+        }
+    }
+
+    fun stopSprinting() {
+        if (kira.bot?.toggled() == true) {
+            sprinting = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindSprint.keyCode, false)
+        }
+    }
+
+    fun startSneaking() {
+        if (kira.bot?.toggled() == true) {
+            sneaking = true
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindSneak.keyCode, true)
+        }
+    }
+
+    fun stopSneaking() {
+        if (kira.bot?.toggled() == true) {
+            sneaking = false
+            KeyBinding.setKeyBindState(kira.mc.gameSettings.keyBindSneak.keyCode, false)
+        }
+    }
+
+    fun singleJump(holdDuration: Int) {
+        startJumping()
+        TimeUtils.setTimeout(this::stopJumping, holdDuration)
+    }
+
+    fun clearAll() {
+        stopForward()
+        stopBackward()
+        stopLeft()
+        stopRight()
+        stopJumping()
+        stopSprinting()
+        stopSneaking()
+    }
+
+    fun clearLeftRight() {
+        stopLeft()
+        stopRight()
+    }
+
+    fun swapLeftRight() {
+        if (left) {
+            stopLeft()
+            startRight()
+        } else if (right) {
+            stopRight()
+            startLeft()
+        }
+    }
+
+    fun forward(): Boolean {
+        return forward
+    }
+
+    fun backward(): Boolean {
+        return backward
+    }
+
+    fun left(): Boolean {
+        return left
+    }
+
+    fun right(): Boolean {
+        return right
+    }
+
+    fun jumping(): Boolean {
+        return jumping
+    }
+
+    fun sprinting(): Boolean {
+        return sprinting
+    }
+
+    fun sneaking(): Boolean {
+        return sneaking
+    }
+
 }


### PR DESCRIPTION
## Summary
- Reintroduce `Movement` helper with keybinding controls.

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c488bd954c83298739022df7e68370