### PR TITLE
Ensure OP bot eats golden apples at low health

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -679,8 +679,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
             val hbActive = now < hbActiveUntil
 
             // =====================  SOINS classiques (gap / regen tardive sur PV) =====================
-            if (((distance > 3f && p.health < 12) || p.health < 9) &&
-                combo < 2 && p.health <= opp.health) {
+            val criticalHealth = p.health < 10
+            if (combo < 2 && (criticalHealth || (((distance > 3f && p.health < 12) || p.health < 9) && p.health <= opp.health))) {
                 if (!Mouse.isUsingProjectile() && !Mouse.isRunningAway() && !Mouse.isUsingPotion() &&
                     !eatingGap && !takingPotion && now - lastPotion > 3500) {
 


### PR DESCRIPTION
## Summary
- make OP duel bot gapple even when winning but below 5 hearts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c7169b193483299fd55d4043c5c54a