### PR TITLE
Add missing ChatUtils.warn helper

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/utils/ChatUtils.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/utils/ChatUtils.kt
@@ -37,6 +37,14 @@ object ChatUtils {
         )
     }
 
+    fun warn(message: String, force: Boolean = false) {
+        // Même prefixe, message en jaune pour un avertissement
+        sendChatMessage(
+            "${EnumChatFormatting.AQUA}[${EnumChatFormatting.BOLD}KIRA${EnumChatFormatting.RESET}${EnumChatFormatting.AQUA}] ${EnumChatFormatting.YELLOW}$message",
+            force
+        )
+    }
+
     fun error(message: String, force: Boolean = false) {
         // Même prefixe, message en rouge
         sendChatMessage(


### PR DESCRIPTION
## Summary
- add `warn` method to `ChatUtils` for yellow warning messages

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cd78cdd4832999c6634f3a8d493b