### PR TITLE
Log flint and steel usage

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
@@ -6,6 +6,7 @@ import best.spaghetcodes.kira.bot.player.Movement
 import best.spaghetcodes.kira.kira
 import best.spaghetcodes.kira.utils.RandomUtils
 import best.spaghetcodes.kira.utils.TimeUtils
+import best.spaghetcodes.kira.utils.ChatUtils
 
 /**
  * Gestion du briquet (flint and steel) pour Hypixel OP.
@@ -24,10 +25,12 @@ interface Flint {
         if (flintUses <= 0) return
         // Unlocalized name is "item.flintAndSteel" -> substring "flintandsteel"
         if (!Inventory.setInvItem("flintandsteel")) {
+            ChatUtils.warn("No flint and steel found in hotbar")
             after()
             return
         }
 
+        ChatUtils.info("About to use flint and steel")
         flintUses--
         Mouse.stopLeftAC()
         kira.mc.thePlayer?.rotationPitch = RandomUtils.randomIntInRange(44, 50).toFloat()


### PR DESCRIPTION
## Summary
- warn when flint and steel is missing from hotbar
- log when flint and steel is about to be used

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c828b1e2a483298725887366ab6a73