### PR TITLE
Maintain retreat while gapping in OP duels

### DIFF
--- a/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/bots/OP.kt
@@ -14,7 +14,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
 
-class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
+class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap, Flint {
 
     override fun getName(): String = "OP"
 
@@ -38,6 +38,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
     var speedPotsLeft = 2
     var regenPotsLeft = 2
     var gapsLeft = 6
+
+    override var flintUses = 5
 
     var lastSpeedUse = 0L
     var lastRegenUse = 0L
@@ -439,99 +441,132 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         Mouse.stopLeftAC()
         Mouse.setUsingProjectile(false)
 
-        val wasForward = Movement.forward()
-        if (close) {
-            Movement.stopForward()
-            Movement.startBackward()
-        }
+        Movement.stopForward()
+        Movement.startBackward()
 
-        // 1) Essai "standard" via helper
-        var eatingStarted = false
-        var decremented = false
+        fun startEatingSequence() {
+            var eatingStarted = false
+            var decremented = false
 
-        fun ensureHoldingGap(): Boolean {
-            val held = p.heldItem?.unlocalizedName?.lowercase() ?: ""
-            if (held.contains("apple")) return true
-            // essaie plusieurs alias
-            return Inventory.setInvItem("gold") ||
-                   Inventory.setInvItem("gap") ||
-                   Inventory.setInvItem("gapple") ||
-                   Inventory.setInvItem("apple") ||
-                   Inventory.setInvItem("golden_apple")
-        }
+            fun ensureHoldingGap(): Boolean {
+                val held = p.heldItem?.unlocalizedName?.lowercase() ?: ""
+                if (held.contains("apple")) return true
+                // essaie plusieurs alias
+                return Inventory.setInvItem("gold") ||
+                       Inventory.setInvItem("gap") ||
+                       Inventory.setInvItem("gapple") ||
+                       Inventory.setInvItem("apple") ||
+                       Inventory.setInvItem("golden_apple")
+            }
 
-        fun tryStartEat(forceHoldMs: Int? = null, after: (() -> Unit)? = null) {
-            val okSelect = ensureHoldingGap()
-            if (okSelect) {
-                // Si le helper interne ne tient pas le clic droit, on le force
-                val hold = forceHoldMs ?: RandomUtils.randomIntInRange(1700, 1900)
-                if (!Mouse.rClickDown) {
-                    Mouse.rClick(hold)
-                }
-                TimeUtils.setTimeout({
-                    if (!isUsingItemSafe(p) && !Mouse.rClickDown) {
-                        // on force une 2e fois (sélection + hold)
-                        ensureHoldingGap()
-                        Mouse.rClick(RandomUtils.randomIntInRange(1700, 1900))
+            fun tryStartEat(forceHoldMs: Int? = null, after: (() -> Unit)? = null) {
+                val okSelect = ensureHoldingGap()
+                if (okSelect) {
+                    // Si le helper interne ne tient pas le clic droit, on le force
+                    val hold = forceHoldMs ?: RandomUtils.randomIntInRange(1700, 1900)
+                    if (!Mouse.rClickDown) {
+                        Mouse.rClick(hold)
                     }
+                    TimeUtils.setTimeout({
+                        if (!isUsingItemSafe(p) && !Mouse.rClickDown) {
+                            // on force une 2e fois (sélection + hold)
+                            ensureHoldingGap()
+                            Mouse.rClick(RandomUtils.randomIntInRange(1700, 1900))
+                        }
+                        after?.invoke()
+                    }, RandomUtils.randomIntInRange(90, 130))
+                } else {
                     after?.invoke()
-                }, RandomUtils.randomIntInRange(90, 130))
-            } else {
-                after?.invoke()
-            }
-        }
-
-        // Appel initial au helper du mixin (peut sélectionner + cliquer selon l'implémentation)
-        useGap(distance, false, facingAway)
-
-        // 2) Vérification after a short delay : si pas en train d'eat -> on force manuellement
-        TimeUtils.setTimeout({
-            eatingStarted = isUsingItemSafe(p)
-            if (!eatingStarted) {
-                // fallback manuel fiable
-                tryStartEat(forceHoldMs = RandomUtils.randomIntInRange(1700, 1900)) {
-                    eatingStarted = isUsingItemSafe(p)
                 }
             }
-        }, RandomUtils.randomIntInRange(90, 130))
 
-        // 3) Confirmation + bookkeeping SEULEMENT si ça a démarré
-        TimeUtils.setTimeout({
-            eatingStarted = eatingStarted || isUsingItemSafe(p)
+            // Appel initial au helper du mixin (peut sélectionner + cliquer selon l'implémentation)
+            useGap(distance, false, facingAway)
 
-            if (eatingStarted) {
-                // On ne décrémente et ne verrouille qu'une fois sûr que ça mange
-                if (!decremented) {
-                    gapsLeft = max(0, gapsLeft - 1)
-                    lastGap = System.currentTimeMillis()
-                    gapLockUntil = lastGap + MIN_GAP_INTERVAL_MS
-                    decremented = true
-                }
-
-                waitUntilFinishedEating(maxWaitMs = 2600) {
-                    if (close) {
-                        Movement.stopBackward()
-                        if (wasForward) Movement.startForward()
+            // 2) Vérification after a short delay : si pas en train d'eat -> on force manuellement
+            TimeUtils.setTimeout({
+                eatingStarted = isUsingItemSafe(p)
+                if (!eatingStarted) {
+                    // fallback manuel fiable
+                    tryStartEat(forceHoldMs = RandomUtils.randomIntInRange(1700, 1900)) {
+                        eatingStarted = isUsingItemSafe(p)
                     }
+                }
+            }, RandomUtils.randomIntInRange(90, 130))
+
+            // 3) Confirmation + bookkeeping SEULEMENT si ça a démarré
+            TimeUtils.setTimeout({
+                eatingStarted = eatingStarted || isUsingItemSafe(p)
+
+                if (eatingStarted) {
+                    // On ne décrémente et ne verrouille qu'une fois sûr que ça mange
+                    if (!decremented) {
+                        gapsLeft = max(0, gapsLeft - 1)
+                        lastGap = System.currentTimeMillis()
+                        gapLockUntil = lastGap + MIN_GAP_INTERVAL_MS
+                        decremented = true
+                    }
+
+                    waitUntilFinishedEating(maxWaitMs = 2600) {
+                        Movement.stopBackward()
+                        Movement.startForward()
+                        Movement.startSprinting()
+                        eatingGap = false
+                        if (Mouse.rClickDown) Mouse.rClickUp()
+                        if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {
+                            Inventory.setInvItem("sword")
+                        }
+                    }
+                } else {
+                    // Échec de démarrage : rollback propre, pas de décrément, reprise combat
+                    Movement.stopBackward()
+                    Movement.startForward()
+                    Movement.startSprinting()
                     eatingGap = false
                     if (Mouse.rClickDown) Mouse.rClickUp()
                     if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {
                         Inventory.setInvItem("sword")
                     }
                 }
-            } else {
-                // Échec de démarrage : rollback propre, pas de décrément, reprise combat
-                if (close) {
-                    Movement.stopBackward()
-                    if (wasForward) Movement.startForward()
-                }
-                eatingGap = false
-                if (Mouse.rClickDown) Mouse.rClickUp()
-                if (!Mouse.isUsingProjectile() && !Mouse.isUsingPotion()) {
-                    Inventory.setInvItem("sword")
-                }
+            }, RandomUtils.randomIntInRange(240, 320))
+        }
+
+        performPreGapAction(distance, close) {
+            startEatingSequence()
+        }
+    }
+
+    private fun performPreGapAction(distance: Float, close: Boolean, onComplete: () -> Unit) {
+        val canUseFlint = flintUses > 0 && Inventory.hasItem("flintandsteel")
+        if (canUseFlint && (close || distance <= 3.8f)) {
+            useFlint(distance) {
+                onComplete()
             }
-        }, RandomUtils.randomIntInRange(240, 320))
+            return
+        }
+
+        val now = System.currentTimeMillis()
+        val hasRod = Inventory.hasItem("rod")
+        val rodReady = hasRod && now >= rodHoldUntil && now >= rodAntiSpamUntil && !Mouse.isUsingProjectile() && !Mouse.isUsingPotion() && !Mouse.rClickDown
+
+        if (rodReady) {
+            castRodNow(distance)
+            val wait = ((rodHoldUntil - System.currentTimeMillis()).coerceAtLeast(0L)).toInt() +
+                    RandomUtils.randomIntInRange(220, 280)
+            TimeUtils.setTimeout({
+                onComplete()
+            }, wait)
+            return
+        }
+
+        if (canUseFlint) {
+            useFlint(distance) {
+                onComplete()
+            }
+            return
+        }
+
+        onComplete()
     }
 
     // =====================  LIFECYCLE  =====================
@@ -540,6 +575,8 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         openingPhaseUntil = gameStartAt + 5500L
         openingDone = false
         openingRegenPending = false
+
+        flintUses = 5
 
         Mouse.startTracking()
         Movement.startSprinting()
@@ -596,6 +633,7 @@ class OP : BotBase("/play duels_op_duel"), Bow, Rod, MovePriority, Potion, Gap {
         speedPotsLeft = 2
         regenPotsLeft = 2
         gapsLeft = 6
+        flintUses = 5
 
         lastSpeedUse = 0L
         lastRegenUse = 0L

--- a/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
+++ b/src/main/kotlin/best/spaghetcodes/kira/bot/features/Flint.kt
@@ -41,7 +41,6 @@ interface Flint {
         Mouse.rClick(clickMs)
 
         TimeUtils.setTimeout({
-            Movement.stopBackward()
             after()
         }, clickMs + RandomUtils.randomIntInRange(120, 180))
     }


### PR DESCRIPTION
## Summary
- allow the OP bot to use the flint and steel five times per duel and reset the counter on start/end
- force the bot to backpedal before any pre-gap action, keep retreating while the apple is eaten, then immediately sprint back into the fight
- keep the flint helper from cancelling backward movement so the retreat survives the pre-gap sequence

## Testing
- ./gradlew build *(fails: unable to tunnel through proxy while downloading com.mojang:minecraft:1.8.9)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a589815083299d035994307e4657